### PR TITLE
Makefile: Use "pkg-config" instead of hardcoded paths

### DIFF
--- a/glue/Makefile
+++ b/glue/Makefile
@@ -20,8 +20,8 @@ ifeq ($(JAVA_HOME),)
 endif
 
 INCDIR_SYS = /usr/include/
-INCDIRS_SYS = glib-2.0 gtk-3.0 pango-1.0 harfbuzz cairo gdk-pixbuf-2.0 atk-1.0 gio-unix-2.0
-INCS:=$(foreach dir,$(INCDIRS_SYS), -I$(INCDIR_SYS)$(dir))
+INCDIRS_SYS = glib-2.0 gtk+-3.0 pango harfbuzz cairo gdk-pixbuf-2.0 atk gio-unix-2.0
+INCS:=$(foreach dir,$(INCDIRS_SYS), `pkg-config --cflags-only-I $(dir)`)
 INCS+= -I../library/build/generated/sources/headers/java/main/ -I$(JAVA_HOME)/include/ -I$(JAVA_HOME)/include/linux/ -I/usr/lib/$(ARCH)-linux-gnu/glib-2.0/include/
 
 libraries = z gtk-3 gdk-3 pangocairo-1.0 pango-1.0 harfbuzz atk-1.0 cairo-gobject cairo gdk_pixbuf-2.0 gio-2.0 gobject-2.0 glib-2.0


### PR DESCRIPTION
E.g. on fedora some header files weren't found (E.g. glibconfig.h)

This fixes this issue in a future-proof way