### PR TITLE
Added libadwaita bindings.

### DIFF
--- a/ci/fedora/Dockerfile
+++ b/ci/fedora/Dockerfile
@@ -19,4 +19,5 @@ RUN dnf -y install java-11-openjdk
 RUN dnf -y install java-11-openjdk-devel
 RUN dnf -y install gcc
 RUN dnf -y install git
+RUN dnf -y install libadwaita-devel
 RUN dnf -y clean all

--- a/examples/src/main/java/examples/App.java
+++ b/examples/src/main/java/examples/App.java
@@ -6,6 +6,7 @@ import ch.bailu.gtk.GTK;
 import ch.bailu.gtk.type.Str;
 import examples.gtk4_demo.HeaderBarSample;
 import examples.gtk4_demo.Pixbufs;
+import examples.libadwaita_demo.AdwaitaDemo;
 
 public class App {
 
@@ -16,7 +17,7 @@ public class App {
         ID = new Str("org.gtk.example");
 
         //new HelloWorld(args);
-        new HeaderBarSample(args);
+        //new HeaderBarSample(args);
         //new Picker(args);
         //new LinksSample(args);
         //new Pixbufs(args);
@@ -32,5 +33,6 @@ public class App {
         //new GlibLoop();
         //new GlibSettings();
         //new GioStreams();
+        new AdwaitaDemo(args);
     }
 }

--- a/examples/src/main/java/examples/libadwaita_demo/AdwaitaDemo.java
+++ b/examples/src/main/java/examples/libadwaita_demo/AdwaitaDemo.java
@@ -1,0 +1,28 @@
+package examples.libadwaita_demo;
+
+import ch.bailu.gtk.adw.Adw;
+import ch.bailu.gtk.adw.Application;
+import ch.bailu.gtk.adw.PreferencesWindow;
+import ch.bailu.gtk.gio.ApplicationFlags;
+import ch.bailu.gtk.gtk.ApplicationWindow;
+import ch.bailu.gtk.gtk.Label;
+import ch.bailu.gtk.helper.ActionHelper;
+import ch.bailu.gtk.type.Str;
+import ch.bailu.gtk.type.Strs;
+
+
+public class AdwaitaDemo {
+    PreferencesWindow prefs;
+    public AdwaitaDemo(String[] args) {
+        Adw.init();
+        Application app = new Application(new Str("org.adw.example"), ApplicationFlags.FLAGS_NONE);
+        app.onActivate(() -> {
+            var window = new ApplicationWindow(app);
+            var label = new Label(new Str("Hello, World"));
+            window.setDefaultSize(200, 200);
+            window.setChild(label);
+            window.present();
+        });
+        app.run(args.length, new Strs(args));
+    }
+}

--- a/generator/src/main/kotlin/ch/bailu/gtk/App.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/App.kt
@@ -32,7 +32,7 @@ fun main(args: Array<String>) {
 
 @Throws(IOException::class, XmlPullParserException::class)
 fun parse(builder: BuilderInterface) {
-    Configuration.NAMESPACES.forEach {Parser(it, builder)}
+    Configuration.NAMESPACES.forEach {Parser(it, builder, !it.notAvailable())}
 }
 
 @Throws(IOException::class)

--- a/generator/src/main/kotlin/ch/bailu/gtk/Configuration.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/Configuration.kt
@@ -24,16 +24,17 @@ class Configuration {
         const val LOG_CALLBACK_TABLE_FILE = "build/callback_table.out"
 
         val NAMESPACES = arrayOf(
-                    NamespaceConfig("GObject-2.0.gir",    GtkDocUrl("gobject")),
-                    NamespaceConfig("Gtk-4.0.gir",        GtkDocUrl("gtk4")),
-                    NamespaceConfig("Gio-2.0.gir",        GtkDocUrl("gio")),
-                    NamespaceConfig("Gdk-4.0.gir",        GtkDocUrl("gdk4")),
-                    NamespaceConfig("PangoCairo-1.0.gir", GtkDocUrl("PangoCairo")),
-                    NamespaceConfig("cairo-custom.gir",   StaticUrl("https://www.cairographics.org/manual/")),
-                    NamespaceConfig("GLib-2.0.gir",       GtkDocUrl("glib")),
-                    //NamespaceConfig("Atk-1.0.gir",        GtkDocUrl("atk")),
-                    NamespaceConfig("Pango-1.0.gir",      GtkDocUrl("Pango")),
-                    NamespaceConfig("GdkPixbuf-2.0.gir",  GtkDocUrl("gdk-pixbuf")))
+                    NamespaceConfig("GObject-2.0.gir",    GtkDocUrl("gobject"), "gobject-2.0"),
+                    NamespaceConfig("Gtk-4.0.gir",        GtkDocUrl("gtk4"), "gtk4"),
+                    NamespaceConfig("Gio-2.0.gir",        GtkDocUrl("gio"), "gio-2.0"),
+                    NamespaceConfig("Gdk-4.0.gir",        GtkDocUrl("gdk4"), "gtk4"),
+                    NamespaceConfig("PangoCairo-1.0.gir", GtkDocUrl("PangoCairo"), "pangocairo"),
+                    NamespaceConfig("cairo-custom.gir",   StaticUrl("https://www.cairographics.org/manual/"), "cairo"),
+                    NamespaceConfig("GLib-2.0.gir",       GtkDocUrl("glib"), "glib-2.0"),
+                    //NamespaceConfig("Atk-1.0.gir",        GtkDocUrl("atk"), "atk"),
+                    NamespaceConfig("Pango-1.0.gir",      GtkDocUrl("Pango"), "pango"),
+                    NamespaceConfig("GdkPixbuf-2.0.gir",  GtkDocUrl("gdk-pixbuf"), "gdk-pixbuf-2.0"),
+                    NamespaceConfig("Adw-1.gir",          StaticUrl("https://gnome.pages.gitlab.gnome.org/libadwaita/doc/"), "libadwaita-1"))
 
 
 

--- a/generator/src/main/kotlin/ch/bailu/gtk/builder/AliasBuilder.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/builder/AliasBuilder.kt
@@ -40,4 +40,8 @@ class AliasBuilder : BuilderInterface{
     override fun buildCallback(callbackTag: CallbackTag) {
         add(namespace, callbackTag)
     }
+    
+    override fun buildErrorStubs(buildStubs: Boolean) {
+        // Ignore
+    }
 }

--- a/generator/src/main/kotlin/ch/bailu/gtk/builder/BuilderInterface.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/builder/BuilderInterface.kt
@@ -18,4 +18,6 @@ interface BuilderInterface {
 
     @Throws(IOException::class)
     fun buildCallback(callbackTag: CallbackTag)
+    
+    fun buildErrorStubs(enabled: Boolean)
 }

--- a/generator/src/main/kotlin/ch/bailu/gtk/builder/ModelBuilder.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/builder/ModelBuilder.kt
@@ -14,6 +14,7 @@ import java.io.Writer
 class ModelBuilder : BuilderInterface {
 
     private var namespace: NamespaceModel = NamespaceModel()
+    private var errorStubs: Boolean = false;
 
     override fun buildStructure(structure: StructureTag) {
         val model = StructureModel(structure, namespace)
@@ -43,7 +44,8 @@ class ModelBuilder : BuilderInterface {
         var out: Writer? = null
         try {
             out = getCWriter(model, namespace)
-            model.write(CWriter(TextWriter(out)))
+            if (!errorStubs)
+			    model.write(CWriter(TextWriter(out)))
         } finally {
             out?.close()
         }
@@ -91,5 +93,9 @@ class ModelBuilder : BuilderInterface {
         } finally {
             out?.close()
         }
+    }
+    
+    override fun buildErrorStubs(build: Boolean) {
+        this.errorStubs = build;  
     }
 }

--- a/generator/src/main/kotlin/ch/bailu/gtk/config/NamespaceConfig.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/config/NamespaceConfig.kt
@@ -4,7 +4,7 @@ import ch.bailu.gtk.Configuration
 import java.io.File
 import java.io.IOException
 
-data class NamespaceConfig(val girFile: String, val docUrl: DocUrl) {
+data class NamespaceConfig(val girFile: String, val docUrl: DocUrl, val pkgConfigName: String? = null) {
 
     fun getFile(): File {
         var result = File(Configuration.GIR_DIR_CUSTOM, girFile)
@@ -22,5 +22,17 @@ data class NamespaceConfig(val girFile: String, val docUrl: DocUrl) {
         }
         println("  --> ${type}: ${result}")
         return result
+    }
+
+    fun notAvailable(): Boolean {
+        if (pkgConfigName == null) {
+            return false
+        }
+        val error = ProcessBuilder("pkg-config", pkgConfigName)
+                        .redirectError(ProcessBuilder.Redirect.INHERIT)
+                        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                        .start()
+                        .waitFor()
+        return error != 0
     }
 }

--- a/generator/src/main/kotlin/ch/bailu/gtk/model/filter/Filter.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/model/filter/Filter.kt
@@ -17,6 +17,9 @@ fun filterMethod(structureModel: StructureModel, methodModel: MethodModel): Bool
     if ("MenuItem" == structureModel.apiName && "activate" == methodModel.apiName) {
         return false
     }
+    if ("ActionRow" == structureModel.apiName && "activate" == methodModel.apiName) {
+        return false
+    }
     if ("ToolPalette" == structureModel.apiName && "getStyle" == methodModel.apiName) {
         return false
     }

--- a/generator/src/main/kotlin/ch/bailu/gtk/parser/Parser.kt
+++ b/generator/src/main/kotlin/ch/bailu/gtk/parser/Parser.kt
@@ -13,10 +13,14 @@ import java.io.Reader
 
 class Parser {
 
-    constructor(namespaceConfig: NamespaceConfig, builder: BuilderInterface) {
+    constructor(namespaceConfig: NamespaceConfig, builder: BuilderInterface, noStubsNeeded: Boolean) {
         var reader: Reader? = null
         try {
+            if (!noStubsNeeded) {
+                println("Generating error stubs for ${namespaceConfig.pkgConfigName} as pkg-config couldn't find the library!")
+            }
             reader = getReader(namespaceConfig.getFile())
+            builder.buildErrorStubs(!noStubsNeeded);
             parse(getParser(reader), DocumentTag(builder, namespaceConfig))
         } finally {
             reader?.close()

--- a/generator/src/main/resources/gir/Adw-1.gir
+++ b/generator/src/main/resources/gir/Adw-1.gir
@@ -1,0 +1,17911 @@
+<?xml version="1.0"?>
+<!-- This file was automatically generated from C sources - DO NOT EDIT!
+To affect the contents of this file, edit the original C definitions,
+and/or use gtk-doc annotations.  -->
+<repository version="1.2"
+            xmlns="http://www.gtk.org/introspection/core/1.0"
+            xmlns:c="http://www.gtk.org/introspection/c/1.0"
+            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="Gio" version="2.0"/>
+  <include name="Gtk" version="4.0"/>
+  <package name="libadwaita-1"/>
+  <c:include name="adwaita.h"/>
+  <namespace name="Adw"
+             version="1"
+             shared-library="libadwaita-1.so.0"
+             c:identifier-prefixes="Adw"
+             c:symbol-prefixes="adw">
+    <class name="ActionRow"
+           c:symbol-prefix="action_row"
+           c:type="AdwActionRow"
+           version="1.0"
+           parent="PreferencesRow"
+           glib:type-name="AdwActionRow"
+           glib:get-type="adw_action_row_get_type"
+           glib:type-struct="ActionRowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-action-row.c"
+           line="12">A [class@Gtk.ListBoxRow] used to present actions.
+
+The `AdwActionRow` widget can have a title, a subtitle and an icon. The row
+can receive additional widgets at its end, or prefix widgets at its start.
+
+It is convenient to present a preference and its related actions.
+
+`AdwActionRow` is unactivatable by default, giving it an activatable widget
+will automatically make it activatable, but unsetting it won't change the
+row's activatability.
+
+## AdwActionRow as GtkBuildable
+
+The `AdwActionRow` implementation of the [iface@Gtk.Buildable] interface
+supports adding a child at its end by specifying “suffix” or omitting the
+“type” attribute of a &lt;child&gt; element.
+
+It also supports adding a child as a prefix widget by specifying “prefix” as
+the “type” attribute of a &lt;child&gt; element.
+
+## CSS nodes
+
+`AdwActionRow` has a main CSS node with name `row`.
+
+It contains the subnode `box.header` for its main horizontal box, and
+`box.title` for the vertical box containing the title and subtitle labels.
+
+It contains subnodes `label.title` and `label.subtitle` representing
+respectively the title label and subtitle label.</doc>
+      <source-position filename="../src/adw-action-row.h" line="37"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_action_row_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="377">Creates a new `AdwActionRow`.</doc>
+        <source-position filename="../src/adw-action-row.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="382">the newly created `AdwActionRow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <virtual-method name="activate" invoker="activate" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="765">Activates @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="767">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <method name="activate"
+              c:identifier="adw_action_row_activate"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="765">Activates @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="83"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="767">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="add_prefix"
+              c:identifier="adw_action_row_add_prefix"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="686">Adds a prefix widget to @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="73"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="688">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="689">a widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_suffix"
+              c:identifier="adw_action_row_add_suffix"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="710">Adds a suffix widget to @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="76"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="712">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="713">a widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_activatable_widget"
+              c:identifier="adw_action_row_get_activatable_widget"
+              glib:get-property="activatable-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="activatable-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="492">Gets the widget activated when @self is activated.</doc>
+        <source-position filename="../src/adw-action-row.h" line="55"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="498">the activatable widget for @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="494">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_action_row_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="441">Gets the icon name for @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="49"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="447">the icon name for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="443">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_subtitle"
+              c:identifier="adw_action_row_get_subtitle"
+              glib:get-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="392">Gets the subtitle for @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="43"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="398">the subtitle for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="394">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_subtitle_lines"
+              c:identifier="adw_action_row_get_subtitle_lines"
+              glib:get-property="subtitle-lines"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle-lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="626">Gets the number of lines at the end of which the subtitle label will be
+ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <source-position filename="../src/adw-action-row.h" line="67"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="635">the number of lines at the end of which the subtitle label will be
+  ellipsized</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="628">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title_lines"
+              c:identifier="adw_action_row_get_title_lines"
+              glib:get-property="title-lines"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title-lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="566">Gets the number of lines at the end of which the title label will be
+ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <source-position filename="../src/adw-action-row.h" line="61"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-action-row.c"
+               line="575">the number of lines at the end of which the title label will be
+  ellipsized</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="568">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_action_row_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="734">Removes a child from @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="79"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="736">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="737">the child to be removed</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_activatable_widget"
+              c:identifier="adw_action_row_set_activatable_widget"
+              glib:set-property="activatable-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="activatable-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="526">Sets the widget to activate when @self is activated.</doc>
+        <source-position filename="../src/adw-action-row.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="528">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="529">the target widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_action_row_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="463">Sets the icon name for @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="51"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="465">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="466">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_subtitle"
+              c:identifier="adw_action_row_set_subtitle"
+              glib:set-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="414">Sets the subtitle for @self.</doc>
+        <source-position filename="../src/adw-action-row.h" line="45"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="416">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="417">the subtitle</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_subtitle_lines"
+              c:identifier="adw_action_row_set_subtitle_lines"
+              glib:set-property="subtitle-lines"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="subtitle-lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="652">Sets the number of lines at the end of which the subtitle label will be
+ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <source-position filename="../src/adw-action-row.h" line="69"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="654">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="subtitle_lines" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="655">the number of lines at the end of which the subtitle label will be ellipsized</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title_lines"
+              c:identifier="adw_action_row_set_title_lines"
+              glib:set-property="title-lines"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title-lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="592">Sets the number of lines at the end of which the title label will be
+ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <source-position filename="../src/adw-action-row.h" line="63"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="594">a `AdwActionRow`</doc>
+            <type name="ActionRow" c:type="AdwActionRow*"/>
+          </instance-parameter>
+          <parameter name="title_lines" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-action-row.c"
+                 line="595">the number of lines at the end of which the title label will be ellipsized</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="activatable-widget"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_activatable_widget"
+                getter="get_activatable_widget">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_action_row_get_activatable_widget"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_action_row_set_activatable_widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="238">The widget to activate when the row is activated.
+
+The row can be activated either by clicking on it, calling
+[method@Adw.ActionRow.activate], or via mnemonics in the title or the
+subtitle. See the [property@Adw.PreferencesRow:use-underline] property to
+enable mnemonics.
+
+The target widget will be activated by emitting the
+[signal@Gtk.Widget::mnemonic-activate] signal on it.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_action_row_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_action_row_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="224">The icon name for this row.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="subtitle"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_subtitle"
+                getter="get_subtitle">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_action_row_get_subtitle"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_action_row_set_subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="260">The subtitle for this row.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="subtitle-lines"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_subtitle_lines"
+                getter="get_subtitle_lines">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_action_row_get_subtitle_lines"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_action_row_set_subtitle_lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="291">The number of lines at the end of which the subtitle label will be
+ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="title-lines"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title_lines"
+                getter="get_title_lines">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_action_row_get_title_lines"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_action_row_set_title_lines"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="274">The number of lines at the end of which the title label will be ellipsized.
+
+If the value is 0, the number of lines won't be limited.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <field name="parent_instance">
+        <type name="PreferencesRow" c:type="AdwPreferencesRow"/>
+      </field>
+      <glib:signal name="activated" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.c"
+             line="311">This signal is emitted after the row has been activated.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="ActionRowClass"
+            c:type="AdwActionRowClass"
+            glib:is-gtype-struct-for="ActionRow">
+      <source-position filename="../src/adw-action-row.h" line="37"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-action-row.h"
+             line="26">The parent class</doc>
+        <type name="PreferencesRowClass" c:type="AdwPreferencesRowClass"/>
+      </field>
+      <field name="activate">
+        <callback name="activate">
+          <source-position filename="../src/adw-action-row.h" line="33"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-action-row.c"
+                   line="767">a `AdwActionRow`</doc>
+              <type name="ActionRow" c:type="AdwActionRow*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="Application"
+           c:symbol-prefix="application"
+           c:type="AdwApplication"
+           version="1.0"
+           parent="Gtk.Application"
+           glib:type-name="AdwApplication"
+           glib:get-type="adw_application_get_type"
+           glib:type-struct="ApplicationClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-application.c"
+           line="11">A base class for Adwaita applications.
+
+`AdwApplication` handles library initialization by calling [func@Adw.init] in
+the default [signal@Gio.Application::startup] signal handler, in turn
+chaining up as required by [class@Gtk.Application]. Therefore, any subclass
+of `AdwApplication` should always chain up its `startup` handler before using
+any Adwaita or GTK API.
+
+## Automatic Resources
+
+`AdwApplication` will automatically load stylesheets located in the
+application's resource base path (see
+[method@Gio.Application.set_resource_base_path], if they're present.
+
+They can be used to add custom styles to the application, as follows:
+
+- `style.css` contains styles that are always present.
+
+- `style-dark.css` contains styles only used when
+  [property@Adw.StyleManager:dark] is `TRUE`.
+
+- `style-hc.css` contains styles used when the system high contrast
+  preference is enabled.
+
+- `style-hc-dark.css` contains styles used when the system high contrast
+  preference is enabled and [property@Adw.StyleManager:dark] is `TRUE`.</doc>
+      <source-position filename="../src/adw-application.h" line="36"/>
+      <implements name="Gio.ActionGroup"/>
+      <implements name="Gio.ActionMap"/>
+      <constructor name="new" c:identifier="adw_application_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-application.c"
+             line="250">Creates a new `AdwApplication`.
+
+If `application_id` is not `NULL`, then it must be valid. See
+[func@Gio.Application.id_is_valid].
+
+If no application ID is given then some features (most notably application
+uniqueness) will be disabled.</doc>
+        <source-position filename="../src/adw-application.h" line="39"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-application.c"
+               line="263">the newly created `AdwApplication`</doc>
+          <type name="Application" c:type="AdwApplication*"/>
+        </return-value>
+        <parameters>
+          <parameter name="application_id"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application.c"
+                 line="252">The application ID</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="flags" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application.c"
+                 line="253">The application flags</doc>
+            <type name="Gio.ApplicationFlags" c:type="GApplicationFlags"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_style_manager"
+              c:identifier="adw_application_get_style_manager"
+              glib:get-property="style-manager"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="style-manager"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-application.c"
+             line="277">Gets the style manager for @self.</doc>
+        <source-position filename="../src/adw-application.h" line="43"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-application.c"
+               line="283">the style manager</doc>
+          <type name="StyleManager" c:type="AdwStyleManager*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application.c"
+                 line="279">a `AdwApplication`</doc>
+            <type name="Application" c:type="AdwApplication*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="style-manager"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_style_manager">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_application_get_style_manager"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-application.c"
+             line="225">The style manager for this application.
+
+This is a convenience property allowing to access `AdwStyleManager` through
+property bindings or expressions.</doc>
+        <type name="StyleManager"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.Application" c:type="GtkApplication"/>
+      </field>
+    </class>
+    <record name="ApplicationClass"
+            c:type="AdwApplicationClass"
+            glib:is-gtype-struct-for="Application">
+      <source-position filename="../src/adw-application.h" line="36"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-application.h"
+             line="28">The parent class</doc>
+        <type name="Gtk.ApplicationClass" c:type="GtkApplicationClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="ApplicationWindow"
+           c:symbol-prefix="application_window"
+           c:type="AdwApplicationWindow"
+           version="1.0"
+           parent="Gtk.ApplicationWindow"
+           glib:type-name="AdwApplicationWindow"
+           glib:get-type="adw_application_window_get_type"
+           glib:type-struct="ApplicationWindowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-application-window.c"
+           line="12">A freeform application window.
+
+`AdwApplicationWindow` is a [class@Gtk.ApplicationWindow] subclass providing
+the same features as [class@Adw.Window].
+
+See [class@Adw.Window] for details.
+
+Using [property@Gtk.Application:menubar] is not supported and may result in
+visual glitches.</doc>
+      <source-position filename="../src/adw-application-window.h" line="30"/>
+      <implements name="Gio.ActionGroup"/>
+      <implements name="Gio.ActionMap"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Native"/>
+      <implements name="Gtk.Root"/>
+      <implements name="Gtk.ShortcutManager"/>
+      <constructor name="new"
+                   c:identifier="adw_application_window_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-application-window.c"
+             line="168">Creates a new `AdwApplicationWindow` for @app.</doc>
+        <source-position filename="../src/adw-application-window.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-application-window.c"
+               line="174">the newly created `AdwApplicationWindow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <parameter name="app" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application-window.c"
+                 line="170">an application instance</doc>
+            <type name="Gtk.Application" c:type="GtkApplication*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_content"
+              c:identifier="adw_application_window_get_content"
+              glib:get-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-application-window.c"
+             line="209">Gets the content widget of @self.
+
+This method should always be used instead of [method@Gtk.Window.get_child].</doc>
+        <source-position filename="../src/adw-application-window.h" line="39"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-application-window.c"
+               line="217">the content widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application-window.c"
+                 line="211">a `AdwApplicationWindow`</doc>
+            <type name="ApplicationWindow" c:type="AdwApplicationWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_content"
+              c:identifier="adw_application_window_set_content"
+              glib:set-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-application-window.c"
+             line="186">Sets the content widget of @self.
+
+This method should always be used instead of [method@Gtk.Window.set_child].</doc>
+        <source-position filename="../src/adw-application-window.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application-window.c"
+                 line="188">a `AdwApplicationWindow`</doc>
+            <type name="ApplicationWindow" c:type="AdwApplicationWindow*"/>
+          </instance-parameter>
+          <parameter name="content"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-application-window.c"
+                 line="189">the content widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="content"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_content"
+                getter="get_content">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_application_window_get_content"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_application_window_set_content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-application-window.c"
+             line="119">The content widget.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.ApplicationWindow" c:type="GtkApplicationWindow"/>
+      </field>
+    </class>
+    <record name="ApplicationWindowClass"
+            c:type="AdwApplicationWindowClass"
+            glib:is-gtype-struct-for="ApplicationWindow">
+      <source-position filename="../src/adw-application-window.h" line="30"/>
+      <field name="parent_class">
+        <type name="Gtk.ApplicationWindowClass"
+              c:type="GtkApplicationWindowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="Avatar"
+           c:symbol-prefix="avatar"
+           c:type="AdwAvatar"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwAvatar"
+           glib:get-type="adw_avatar_get_type"
+           glib:type-struct="AvatarClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-avatar.c"
+           line="20">A widget displaying an image, with a generated fallback.
+
+`AdwAvatar` is a widget that shows a round avatar.
+
+`AdwAvatar` generates an avatar with the initials of  the
+[property@Adw.Avatar:text] on top of a colored background.
+
+The color is picked based on the hash of the [property@Adw.Avatar:text].
+
+If [property@Adw.Avatar:show-initials] is set to `FALSE`,
+[property@Adw.Avatar:icon-name] or `avatar-default-symbolic` is shown instead
+of the initials.
+
+Use [property@Adw.Avatar:custom-image] to set a custom image.
+
+## CSS nodes
+
+`AdwAvatar` has a single CSS node with name `avatar`.</doc>
+      <source-position filename="../src/adw-avatar.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_avatar_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="418">Creates a new `AdwAvatar`.</doc>
+        <source-position filename="../src/adw-avatar.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="426">the newly created `AdwAvatar`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <parameter name="size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="420">The size of the avatar</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+          <parameter name="text"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="421">the text used to get the initials and color</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="show_initials" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="422">whether to use initials instead of an icon as fallback</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="draw_to_texture"
+              c:identifier="adw_avatar_draw_to_texture"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="703">Renders @self into a [class@Gdk.Texture] at @scale_factor.
+
+This can be used to export the fallback avatar.</doc>
+        <source-position filename="../src/adw-avatar.h" line="60"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="712">the texture</doc>
+          <type name="Gdk.Texture" c:type="GdkTexture*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="705">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="scale_factor" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="706">The scale factor</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_custom_image"
+              c:identifier="adw_avatar_get_custom_image"
+              glib:get-property="custom-image"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="custom-image"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="582">Gets the custom image paintable.</doc>
+        <source-position filename="../src/adw-avatar.h" line="48"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="588">the custom image</doc>
+          <type name="Gdk.Paintable" c:type="GdkPaintable*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="584">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_avatar_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="442">Gets the name of an icon to use as a fallback.</doc>
+        <source-position filename="../src/adw-avatar.h" line="30"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="448">the icon name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="444">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_initials"
+              c:identifier="adw_avatar_get_show_initials"
+              glib:get-property="show-initials"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="show-initials"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="537">Gets whether initials are used instead of an icon on the fallback avatar.</doc>
+        <source-position filename="../src/adw-avatar.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="543">whether initials are used instead of an icon as fallback</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="539">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_size"
+              c:identifier="adw_avatar_get_size"
+              glib:get-property="size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="650">Gets the size of the avatar.</doc>
+        <source-position filename="../src/adw-avatar.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="656">the size of the avatar</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="652">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_text"
+              c:identifier="adw_avatar_get_text"
+              glib:get-property="text"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="text"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="488">Gets the text used to generate the fallback initials and color.</doc>
+        <source-position filename="../src/adw-avatar.h" line="36"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-avatar.c"
+               line="494">the text used to generate the fallback initials and
+  color</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="490">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_custom_image"
+              c:identifier="adw_avatar_set_custom_image"
+              glib:set-property="custom-image"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="custom-image"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="600">Sets the custom image paintable.</doc>
+        <source-position filename="../src/adw-avatar.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="602">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="custom_image"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="603">a custom image</doc>
+            <type name="Gdk.Paintable" c:type="GdkPaintable*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_avatar_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="460">Sets the name of an icon to use as a fallback.
+
+If no name is set, `avatar-default-symbolic` will be used.</doc>
+        <source-position filename="../src/adw-avatar.h" line="32"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="462">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="463">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_initials"
+              c:identifier="adw_avatar_set_show_initials"
+              glib:set-property="show-initials"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="show-initials"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="555">Sets whether to use initials instead of an icon on the fallback avatar.</doc>
+        <source-position filename="../src/adw-avatar.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="557">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="show_initials" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="558">whether to use initials instead of an icon as fallback</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_size"
+              c:identifier="adw_avatar_set_size"
+              glib:set-property="size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="668">Sets the size of the avatar.</doc>
+        <source-position filename="../src/adw-avatar.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="670">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="671">The size of the avatar</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_text"
+              c:identifier="adw_avatar_set_text"
+              glib:set-property="text"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="text"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="507">Sets the text used to generate the fallback initials and color.</doc>
+        <source-position filename="../src/adw-avatar.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="509">a `AdwAvatar`</doc>
+            <type name="Avatar" c:type="AdwAvatar*"/>
+          </instance-parameter>
+          <parameter name="text"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-avatar.c"
+                 line="510">the text used to get the initials and color</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="custom-image"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_custom_image"
+                getter="get_custom_image">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_avatar_get_custom_image"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_avatar_set_custom_image"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="355">A custom image to use instead of initials or icon.</doc>
+        <type name="Gdk.Paintable"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_avatar_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_avatar_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="306">The name of an icon to use as a fallback.
+
+If no name is set, `avatar-default-symbolic` will be used.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="show-initials"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_show_initials"
+                getter="get_show_initials">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_avatar_get_show_initials"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_avatar_set_show_initials"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="339">Whether initials are used instead of an icon on the fallback avatar.
+
+See [property@Adw.Avatar:icon-name] for how to change the fallback icon.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_size"
+                getter="get_size">
+        <attribute name="org.gtk.Property.get" value="adw_avatar_get_size"/>
+        <attribute name="org.gtk.Property.set" value="adw_avatar_set_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="369">The size of the avatar.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="text"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_text"
+                getter="get_text">
+        <attribute name="org.gtk.Property.get" value="adw_avatar_get_text"/>
+        <attribute name="org.gtk.Property.set" value="adw_avatar_set_text"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-avatar.c"
+             line="322">Sets the text used to generate the fallback initials and color.
+
+It's only used to generate the color if [property@Adw.Avatar:show-initials]
+is `FALSE`.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="AvatarClass"
+            c:type="AdwAvatarClass"
+            glib:is-gtype-struct-for="Avatar">
+      <source-position filename="../src/adw-avatar.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="Bin"
+           c:symbol-prefix="bin"
+           c:type="AdwBin"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwBin"
+           glib:get-type="adw_bin_get_type"
+           glib:type-struct="BinClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-bin.c"
+           line="14">A widget with one child.
+
+The `AdwBin` widget has only one child, set with the [property@Adw.Bin:child]
+property.
+
+It is useful for deriving subclasses, since it provides common code needed
+for handling a single child widget.</doc>
+      <source-position filename="../src/adw-bin.h" line="29"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_bin_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-bin.c"
+             line="150">Creates a new `AdwBin`.</doc>
+        <source-position filename="../src/adw-bin.h" line="32"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-bin.c"
+               line="155">the new created `AdwBin`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_child"
+              c:identifier="adw_bin_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-bin.c"
+             line="165">Gets the child widget of @self.</doc>
+        <source-position filename="../src/adw-bin.h" line="35"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-bin.c"
+               line="171">the child widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-bin.c"
+                 line="167">a `AdwBin`</doc>
+            <type name="Bin" c:type="AdwBin*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_child"
+              c:identifier="adw_bin_set_child"
+              glib:set-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-bin.c"
+             line="187">Sets the child widget of @self.</doc>
+        <source-position filename="../src/adw-bin.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-bin.c"
+                 line="189">a `AdwBin`</doc>
+            <type name="Bin" c:type="AdwBin*"/>
+          </instance-parameter>
+          <parameter name="child"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-bin.c"
+                 line="190">the child widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get" value="adw_bin_get_child"/>
+        <attribute name="org.gtk.Property.set" value="adw_bin_set_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-bin.c"
+             line="106">The child widget of the `AdwBin`.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.Widget" c:type="GtkWidget"/>
+      </field>
+    </class>
+    <record name="BinClass"
+            c:type="AdwBinClass"
+            glib:is-gtype-struct-for="Bin">
+      <source-position filename="../src/adw-bin.h" line="29"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="ButtonContent"
+           c:symbol-prefix="button_content"
+           c:type="AdwButtonContent"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwButtonContent"
+           glib:get-type="adw_button_content_get_type"
+           glib:type-struct="ButtonContentClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-button-content.c"
+           line="14">A helper widget for creating buttons.
+
+`AdwButtonContent` is a box-like widget with an icon and a label.
+
+It's intended to be used as a direct child of [class@Gtk.Button],
+[class@Gtk.MenuButton] or [class@Adw.SplitButton], when they need to habe
+both an icon and a label, as follows:
+
+```xml
+&lt;object class="GtkButton"&gt;
+  &lt;property name="child"&gt;
+    &lt;object class="AdwButtonContent"&gt;
+      &lt;property name="icon-name"&gt;document-open-symbolic&lt;/property&gt;
+      &lt;property name="label" translatable="yes"&gt;_Open&lt;/property&gt;
+      &lt;property name="use-underline"&gt;True&lt;/property&gt;
+    &lt;/object&gt;
+  &lt;/property&gt;
+&lt;/object&gt;
+```
+
+`AdwButtonContent` handles style classes and connecting the mnemonic to the
+button automatically.
+
+## CSS nodes
+
+```
+buttoncontent
+├── image
+╰── label
+```
+
+`AdwSplitButton`'s CSS node is called `buttoncontent`. It contains the
+subnodes `image` and `label`.
+
+When inside a `GtkButton` or `AdwSplitButton`, the button will receive the
+`.image-text-button` style class. When inside a `GtkMenuButton`, the
+internal `GtkButton` will receive it instead.
+
+## Accessibility
+
+`AdwSplitButton` uses the `GTK_ACCESSIBLE_ROLE_GROUP` role.</doc>
+      <source-position filename="../src/adw-button-content.h" line="24"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_button_content_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="285">Creates a new `AdwButtonContent`.</doc>
+        <source-position filename="../src/adw-button-content.h" line="27"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-button-content.c"
+               line="290">the new created `AdwButtonContent`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_icon_name"
+              c:identifier="adw_button_content_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="300">Gets the name of the displayed icon.</doc>
+        <source-position filename="../src/adw-button-content.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-button-content.c"
+               line="306">the icon name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="302">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_label"
+              c:identifier="adw_button_content_get_label"
+              glib:get-property="label"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="348">Gets the displayed label.</doc>
+        <source-position filename="../src/adw-button-content.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-button-content.c"
+               line="354">the label</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="350">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_underline"
+              c:identifier="adw_button_content_get_use_underline"
+              glib:get-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="393">Gets whether an underline in the text indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-button-content.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-button-content.c"
+               line="399">whether an underline in the text indicates a mnemonic</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="395">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_button_content_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="318">Sets the name of the displayed icon.</doc>
+        <source-position filename="../src/adw-button-content.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="320">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+          <parameter name="icon_name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="321">the new icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_label"
+              c:identifier="adw_button_content_set_label"
+              glib:set-property="label"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="366">Sets the displayed label.</doc>
+        <source-position filename="../src/adw-button-content.h" line="32"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="368">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+          <parameter name="label" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="369">the new label</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_underline"
+              c:identifier="adw_button_content_set_use_underline"
+              glib:set-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="411">Sets whether an underline in the text indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-button-content.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="413">a `AdwButtonContent`</doc>
+            <type name="ButtonContent" c:type="AdwButtonContent*"/>
+          </instance-parameter>
+          <parameter name="use_underline" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-button-content.c"
+                 line="414">whether an underline in the text indicates a mnemonic</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_button_content_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_button_content_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="208">The name of the displayed icon.
+
+If empty, the icon is not shown.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="label"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_label"
+                getter="get_label">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_button_content_get_label"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_button_content_set_label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="224">The displayed label.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="use-underline"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_underline"
+                getter="get_use_underline">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_button_content_get_use_underline"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_button_content_set_use_underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-button-content.c"
+             line="238">Whether an underline in the text indicates a mnemonic.
+
+The mnemonic can be used to activate the parent button.
+
+See [property@Adw.ButtonContent:label].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="ButtonContentClass"
+            c:type="AdwButtonContentClass"
+            glib:is-gtype-struct-for="ButtonContent">
+      <source-position filename="../src/adw-button-content.h" line="24"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <function-macro name="CHECK_VERSION"
+                    c:identifier="ADW_CHECK_VERSION"
+                    introspectable="0">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.h"
+           line="65">Compile-time version checking. Evaluates to `TRUE` if the version
+of Adwaita is greater than the required one.</doc>
+      <source-position filename="../src/adw-version.h" line="73"/>
+      <parameters>
+        <parameter name="major">
+          <doc xml:space="preserve"
+               filename="../src/adw-version.h"
+               line="67">required major version</doc>
+        </parameter>
+        <parameter name="minor">
+          <doc xml:space="preserve"
+               filename="../src/adw-version.h"
+               line="68">required minor version</doc>
+        </parameter>
+        <parameter name="micro">
+          <doc xml:space="preserve"
+               filename="../src/adw-version.h"
+               line="69">required micro version</doc>
+        </parameter>
+      </parameters>
+    </function-macro>
+    <class name="Carousel"
+           c:symbol-prefix="carousel"
+           c:type="AdwCarousel"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwCarousel"
+           glib:get-type="adw_carousel_get_type"
+           glib:type-struct="CarouselClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-carousel.c"
+           line="22">A paginated scrolling widget.
+
+The `AdwCarousel` widget can be used to display a set of pages with
+swipe-based navigation between them.
+
+[class@Adw.CarouselIndicatorDots] and [class@Adw.CarouselIndicatorLines] can
+be used to provide page indicators for `AdwCarousel`.
+
+## CSS nodes
+
+`AdwCarousel` has a single CSS node with name `carousel`.</doc>
+      <source-position filename="../src/adw-carousel.h" line="22"/>
+      <implements name="Swipeable"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new" c:identifier="adw_carousel_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1162">Creates a new `AdwCarousel`.</doc>
+        <source-position filename="../src/adw-carousel.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1167">the newly created `AdwCarousel`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="append" c:identifier="adw_carousel_append" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1196">Appends @child to @self.</doc>
+        <source-position filename="../src/adw-carousel.h" line="31"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1198">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1199">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_allow_long_swipes"
+              c:identifier="adw_carousel_get_allow_long_swipes"
+              glib:get-property="allow-long-swipes"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="allow-long-swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1683">Gets whether to allow swiping for more than one page at a time.</doc>
+        <source-position filename="../src/adw-carousel.h" line="94"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1689">`TRUE` if long swipes are allowed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1685">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_allow_mouse_drag"
+              c:identifier="adw_carousel_get_allow_mouse_drag"
+              glib:get-property="allow-mouse-drag"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="allow-mouse-drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1597">Sets whether @self can be dragged with mouse pointer.</doc>
+        <source-position filename="../src/adw-carousel.h" line="82"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1603">whether @self can be dragged with mouse pointer</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1599">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_allow_scroll_wheel"
+              c:identifier="adw_carousel_get_allow_scroll_wheel"
+              glib:get-property="allow-scroll-wheel"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="allow-scroll-wheel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1640">Gets whether @self will respond to scroll wheel events.</doc>
+        <source-position filename="../src/adw-carousel.h" line="88"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1646">`TRUE` if @self will respond to scroll wheel events</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1642">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_animation_duration"
+              c:identifier="adw_carousel_get_animation_duration"
+              glib:get-property="animation-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="animation-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1556">Gets the animation duration used by [method@Adw.Carousel.scroll_to].</doc>
+        <source-position filename="../src/adw-carousel.h" line="76"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1562">animation duration in milliseconds</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1558">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_interactive"
+              c:identifier="adw_carousel_get_interactive"
+              glib:get-property="interactive"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="interactive"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1471">Gets whether @self can be navigated.</doc>
+        <source-position filename="../src/adw-carousel.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1477">whether @self can be navigated</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1473">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_n_pages"
+              c:identifier="adw_carousel_get_n_pages"
+              glib:get-property="n-pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="n-pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1422">Gets the number of pages in @self.</doc>
+        <source-position filename="../src/adw-carousel.h" line="59"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1428">the number of pages in @self</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1424">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_nth_page"
+              c:identifier="adw_carousel_get_nth_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1397">Gets the page at position @n.</doc>
+        <source-position filename="../src/adw-carousel.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1404">the page</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1399">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="n" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1400">index of the page</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_position"
+              c:identifier="adw_carousel_get_position"
+              glib:get-property="position"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="position"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1451">Gets current scroll position in @self.
+
+It's unitless, 1 matches 1 page.</doc>
+        <source-position filename="../src/adw-carousel.h" line="61"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1459">the scroll position</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1453">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_reveal_duration"
+              c:identifier="adw_carousel_get_reveal_duration"
+              glib:get-property="reveal-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reveal-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1726">Gets duration of the animation used when adding or removing pages.</doc>
+        <source-position filename="../src/adw-carousel.h" line="100"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1732">the duration</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1728">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_spacing"
+              c:identifier="adw_carousel_get_spacing"
+              glib:get-property="spacing"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="spacing"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1514">Gets spacing between pages in pixels.</doc>
+        <source-position filename="../src/adw-carousel.h" line="70"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel.c"
+               line="1520">spacing between pages</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1516">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="insert" c:identifier="adw_carousel_insert" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1215">Inserts @child into @self at position @position.
+
+If position is -1, or larger than the number of pages,
+@child will be appended to the end.</doc>
+        <source-position filename="../src/adw-carousel.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1217">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1218">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1219">the position to insert @child at</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="prepend" c:identifier="adw_carousel_prepend" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1177">Prepends @child to @self.</doc>
+        <source-position filename="../src/adw-carousel.h" line="28"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1179">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1180">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_carousel_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1317">Removes @child from @self.</doc>
+        <source-position filename="../src/adw-carousel.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1319">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1320">a widget to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder" c:identifier="adw_carousel_reorder" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1258">Moves @child into position @position.
+
+If position is -1, or larger than the number of pages, @child will be moved
+at the end.</doc>
+        <source-position filename="../src/adw-carousel.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1260">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1261">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1262">the position to move @child to</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="scroll_to"
+              c:identifier="adw_carousel_scroll_to"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1352">Scrolls to @widget with an animation.
+
+The [property@Adw.Carousel:animation-duration] property can be used to
+control the duration.</doc>
+        <source-position filename="../src/adw-carousel.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1354">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1355">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="scroll_to_full"
+              c:identifier="adw_carousel_scroll_to_full"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1374">Scrolls to @widget with an animation.</doc>
+        <source-position filename="../src/adw-carousel.h" line="51"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1376">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1377">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1378">animation duration in milliseconds</doc>
+            <type name="gint64" c:type="gint64"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_long_swipes"
+              c:identifier="adw_carousel_set_allow_long_swipes"
+              glib:set-property="allow-long-swipes"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="allow-long-swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1701">Sets whether to allow swiping for more than one page at a time.</doc>
+        <source-position filename="../src/adw-carousel.h" line="96"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1703">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="allow_long_swipes" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1704">whether to allow long swipes</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_mouse_drag"
+              c:identifier="adw_carousel_set_allow_mouse_drag"
+              glib:set-property="allow-mouse-drag"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="allow-mouse-drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1615">Sets whether @self can be dragged with mouse pointer.</doc>
+        <source-position filename="../src/adw-carousel.h" line="84"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1617">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="allow_mouse_drag" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1618">whether @self can be dragged with mouse pointer</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_scroll_wheel"
+              c:identifier="adw_carousel_set_allow_scroll_wheel"
+              glib:set-property="allow-scroll-wheel"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="allow-scroll-wheel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1658">Sets whether @self will respond to scroll wheel events.</doc>
+        <source-position filename="../src/adw-carousel.h" line="90"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1660">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="allow_scroll_wheel" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1661">whether @self will respond to scroll wheel events</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_animation_duration"
+              c:identifier="adw_carousel_set_animation_duration"
+              glib:set-property="animation-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="animation-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1574">Sets the animation duration used by [method@Adw.Carousel.scroll_to].</doc>
+        <source-position filename="../src/adw-carousel.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1576">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1577">animation duration in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_interactive"
+              c:identifier="adw_carousel_set_interactive"
+              glib:set-property="interactive"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="interactive"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1489">Sets whether @self can be navigated.</doc>
+        <source-position filename="../src/adw-carousel.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1491">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="interactive" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1492">whether @self can be navigated</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_reveal_duration"
+              c:identifier="adw_carousel_set_reveal_duration"
+              glib:set-property="reveal-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="reveal-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1744">Sets duration of the animation used when adding or removing pages.</doc>
+        <source-position filename="../src/adw-carousel.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1746">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="reveal_duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1747">the new reveal duration value</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_spacing"
+              c:identifier="adw_carousel_set_spacing"
+              glib:set-property="spacing"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="spacing"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1532">Sets spacing between pages in pixels.</doc>
+        <source-position filename="../src/adw-carousel.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1534">a `AdwCarousel`</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </instance-parameter>
+          <parameter name="spacing" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1535">the new spacing value</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="allow-long-swipes"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_long_swipes"
+                getter="get_allow_long_swipes">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_allow_long_swipes"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_allow_long_swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="996">Whether to allow swiping for more than one page at a time.
+
+If the value is `FALSE`, each swipe can only move to the adjacent pages.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="allow-mouse-drag"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_mouse_drag"
+                getter="get_allow_mouse_drag">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_allow_mouse_drag"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_allow_mouse_drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="964">Sets whether the `AdwCarousel` can be dragged with mouse pointer.
+
+If the value is `FALSE`, dragging is only available on touch.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="allow-scroll-wheel"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_scroll_wheel"
+                getter="get_allow_scroll_wheel">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_allow_scroll_wheel"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_allow_scroll_wheel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="980">Whether the widget will respond to scroll wheel events.
+
+If the value is `FALSE`, wheel events will be ignored.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="animation-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_animation_duration"
+                getter="get_animation_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_animation_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_animation_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="950">Animation duration in milliseconds, used by [method@Adw.Carousel.scroll_to].</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="interactive"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_interactive"
+                getter="get_interactive">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_interactive"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_interactive"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="917">Whether the carousel can be navigated.
+
+This can be used to temporarily disable a `AdwCarousel` to only allow
+navigating it in a certain state.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="n-pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_n_pages">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_n_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="883">The number of pages in a `AdwCarousel`.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="position"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_position">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_position"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="899">Current scrolling position, unitless.
+
+1 matches 1 page. Use [method@Adw.Carousel.scroll_to] for changing it.</doc>
+        <type name="gdouble" c:type="gdouble"/>
+      </property>
+      <property name="reveal-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_reveal_duration"
+                getter="get_reveal_duration">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1012">Page reveal duration in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="spacing"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_spacing"
+                getter="get_spacing">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_get_spacing"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_set_spacing"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="934">Spacing between pages in pixels.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <glib:signal name="page-changed" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel.c"
+             line="1034">This signal is emitted after a page has been changed.
+
+It can be used to implement "infinite scrolling" by amending the pages
+after every scroll.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="index" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel.c"
+                 line="1037">current page</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </class>
+    <record name="CarouselClass"
+            c:type="AdwCarouselClass"
+            glib:is-gtype-struct-for="Carousel">
+      <source-position filename="../src/adw-carousel.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="CarouselIndicatorDots"
+           c:symbol-prefix="carousel_indicator_dots"
+           c:type="AdwCarouselIndicatorDots"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwCarouselIndicatorDots"
+           glib:get-type="adw_carousel_indicator_dots_get_type"
+           glib:type-struct="CarouselIndicatorDotsClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-carousel-indicator-dots.c"
+           line="24">A dots indicator for [class@Adw.Carousel].
+
+The `AdwCarouselIndicatorDots` widget shows a set of dots for each page of a
+given [class@Adw.Carousel]. The dot representing the carousel's active page
+is larger and more opaque than the others, the transition to the active and
+inactive state is gradual to match the carousel's position.
+
+See also [class@Adw.CarouselIndicatorLines].
+
+## CSS nodes
+
+`AdwCarouselIndicatorDots` has a single CSS node with name
+`carouselindicatordots`.</doc>
+      <source-position filename="../src/adw-carousel-indicator-dots.h"
+                       line="23"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new"
+                   c:identifier="adw_carousel_indicator_dots_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-dots.c"
+             line="374">Creates a new `AdwCarouselIndicatorDots`.</doc>
+        <source-position filename="../src/adw-carousel-indicator-dots.h"
+                         line="26"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel-indicator-dots.c"
+               line="379">the newly created `AdwCarouselIndicatorDots`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_carousel"
+              c:identifier="adw_carousel_indicator_dots_get_carousel"
+              glib:get-property="carousel"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-dots.c"
+             line="389">Gets the displayed carousel.</doc>
+        <source-position filename="../src/adw-carousel-indicator-dots.h"
+                         line="29"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel-indicator-dots.c"
+               line="395">the displayed carousel</doc>
+          <type name="Carousel" c:type="AdwCarousel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-dots.c"
+                 line="391">a `AdwCarouselIndicatorDots`</doc>
+            <type name="CarouselIndicatorDots"
+                  c:type="AdwCarouselIndicatorDots*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_carousel"
+              c:identifier="adw_carousel_indicator_dots_set_carousel"
+              glib:set-property="carousel"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-dots.c"
+             line="407">Sets the displayed carousel.</doc>
+        <source-position filename="../src/adw-carousel-indicator-dots.h"
+                         line="31"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-dots.c"
+                 line="409">a `AdwCarouselIndicatorDots`</doc>
+            <type name="CarouselIndicatorDots"
+                  c:type="AdwCarouselIndicatorDots*"/>
+          </instance-parameter>
+          <parameter name="carousel"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-dots.c"
+                 line="410">a carousel</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="carousel"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_carousel"
+                getter="get_carousel">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_indicator_dots_get_carousel"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_indicator_dots_set_carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-dots.c"
+             line="346">The displayed carousel.</doc>
+        <type name="Carousel"/>
+      </property>
+    </class>
+    <record name="CarouselIndicatorDotsClass"
+            c:type="AdwCarouselIndicatorDotsClass"
+            glib:is-gtype-struct-for="CarouselIndicatorDots">
+      <source-position filename="../src/adw-carousel-indicator-dots.h"
+                       line="23"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="CarouselIndicatorLines"
+           c:symbol-prefix="carousel_indicator_lines"
+           c:type="AdwCarouselIndicatorLines"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwCarouselIndicatorLines"
+           glib:get-type="adw_carousel_indicator_lines_get_type"
+           glib:type-struct="CarouselIndicatorLinesClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-carousel-indicator-lines.c"
+           line="23">A lines indicator for [class@Adw.Carousel].
+
+The `AdwCarouselIndicatorLines` widget shows a set of lines for each page of
+a given [class@Adw.Carousel]. The carousel's active page is shown as another
+line that moves between them to match the carousel's position.
+
+See also [class@Adw.CarouselIndicatorDots].
+
+## CSS nodes
+
+`AdwCarouselIndicatorLines` has a single CSS node with name
+`carouselindicatorlines`.</doc>
+      <source-position filename="../src/adw-carousel-indicator-lines.h"
+                       line="23"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new"
+                   c:identifier="adw_carousel_indicator_lines_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-lines.c"
+             line="359">Creates a new `AdwCarouselIndicatorLines`.</doc>
+        <source-position filename="../src/adw-carousel-indicator-lines.h"
+                         line="26"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel-indicator-lines.c"
+               line="364">the newly created `AdwCarouselIndicatorLines`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_carousel"
+              c:identifier="adw_carousel_indicator_lines_get_carousel"
+              glib:get-property="carousel"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-lines.c"
+             line="374">Gets the displayed carousel.</doc>
+        <source-position filename="../src/adw-carousel-indicator-lines.h"
+                         line="29"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-carousel-indicator-lines.c"
+               line="380">the displayed carousel</doc>
+          <type name="Carousel" c:type="AdwCarousel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-lines.c"
+                 line="376">a `AdwCarouselIndicatorLines`</doc>
+            <type name="CarouselIndicatorLines"
+                  c:type="AdwCarouselIndicatorLines*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_carousel"
+              c:identifier="adw_carousel_indicator_lines_set_carousel"
+              glib:set-property="carousel"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-lines.c"
+             line="392">Sets the displayed carousel.</doc>
+        <source-position filename="../src/adw-carousel-indicator-lines.h"
+                         line="31"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-lines.c"
+                 line="394">a `AdwCarouselIndicatorLines`</doc>
+            <type name="CarouselIndicatorLines"
+                  c:type="AdwCarouselIndicatorLines*"/>
+          </instance-parameter>
+          <parameter name="carousel"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-carousel-indicator-lines.c"
+                 line="395">a carousel</doc>
+            <type name="Carousel" c:type="AdwCarousel*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="carousel"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_carousel"
+                getter="get_carousel">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_carousel_indicator_lines_get_carousel"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_carousel_indicator_lines_set_carousel"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-carousel-indicator-lines.c"
+             line="331">The displayed carousel.</doc>
+        <type name="Carousel"/>
+      </property>
+    </class>
+    <record name="CarouselIndicatorLinesClass"
+            c:type="AdwCarouselIndicatorLinesClass"
+            glib:is-gtype-struct-for="CarouselIndicatorLines">
+      <source-position filename="../src/adw-carousel-indicator-lines.h"
+                       line="23"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <enumeration name="CenteringPolicy"
+                 version="1.0"
+                 glib:type-name="AdwCenteringPolicy"
+                 glib:get-type="adw_centering_policy_get_type"
+                 c:type="AdwCenteringPolicy">
+      <doc xml:space="preserve"
+           filename="../src/adw-header-bar.c"
+           line="107">Describes title centering behavior of a [class@Adw.HeaderBar] widget.</doc>
+      <member name="loose"
+              value="0"
+              c:identifier="ADW_CENTERING_POLICY_LOOSE"
+              glib:nick="loose"
+              glib:name="ADW_CENTERING_POLICY_LOOSE">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="109">Keep the title centered when possible</doc>
+      </member>
+      <member name="strict"
+              value="1"
+              c:identifier="ADW_CENTERING_POLICY_STRICT"
+              glib:nick="strict"
+              glib:name="ADW_CENTERING_POLICY_STRICT">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="110">Keep the title centered at all cost</doc>
+      </member>
+    </enumeration>
+    <class name="Clamp"
+           c:symbol-prefix="clamp"
+           c:type="AdwClamp"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwClamp"
+           glib:get-type="adw_clamp_get_type"
+           glib:type-struct="ClampClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-clamp.c"
+           line="13">A widget constraining its child to a given size.
+
+The `AdwClamp` widget constrains the size of the widget it contains to a
+given maximum size. It will constrain the width if it is horizontal, or the
+height if it is vertical. The expansion of the child from its minimum to its
+maximum size is eased out for a smooth transition.
+
+If the child requires more than the requested maximum size, it will be
+allocated the minimum size it can fit in instead.
+
+## CSS nodes
+
+`AdwClamp` has a single CSS node with name `clamp`.
+
+Its children will receive the style classes `.large` when the child reached
+its maximum size, `.small` when the clamp allocates its full size to the
+child, `.medium` in-between, or none if it hasn't computed its size yet.</doc>
+      <source-position filename="../src/adw-clamp.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new" c:identifier="adw_clamp_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="252">Creates a new `AdwClamp`.</doc>
+        <source-position filename="../src/adw-clamp.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp.c"
+               line="257">the newly created `AdwClamp`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_child"
+              c:identifier="adw_clamp_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="267">Gets the child widget of @self.</doc>
+        <source-position filename="../src/adw-clamp.h" line="28"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp.c"
+               line="273">the child widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="269">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_maximum_size"
+              c:identifier="adw_clamp_get_maximum_size"
+              glib:get-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="314">Gets the maximum size allocated to the child.</doc>
+        <source-position filename="../src/adw-clamp.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp.c"
+               line="320">the maximum size to allocate to the child</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="316">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tightening_threshold"
+              c:identifier="adw_clamp_get_tightening_threshold"
+              glib:get-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="363">Gets the size above which the child is clamped.</doc>
+        <source-position filename="../src/adw-clamp.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp.c"
+               line="369">the size above which the child is clamped</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="365">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_child"
+              c:identifier="adw_clamp_set_child"
+              glib:set-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="285">Sets the child widget of @self.</doc>
+        <source-position filename="../src/adw-clamp.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="287">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+          <parameter name="child"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="288">the child widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_maximum_size"
+              c:identifier="adw_clamp_set_maximum_size"
+              glib:set-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="336">Sets the maximum size allocated to the child.</doc>
+        <source-position filename="../src/adw-clamp.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="338">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+          <parameter name="maximum_size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="339">the maximum size</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tightening_threshold"
+              c:identifier="adw_clamp_set_tightening_threshold"
+              glib:set-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="385">Sets the size above which the child is clamped.</doc>
+        <source-position filename="../src/adw-clamp.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="387">a `AdwClamp`</doc>
+            <type name="Clamp" c:type="AdwClamp*"/>
+          </instance-parameter>
+          <parameter name="tightening_threshold" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp.c"
+                 line="388">the tightening threshold</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get" value="adw_clamp_get_child"/>
+        <attribute name="org.gtk.Property.set" value="adw_clamp_set_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="163">The child widget of the `AdwClamp`.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="maximum-size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_maximum_size"
+                getter="get_maximum_size">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_get_maximum_size"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_set_maximum_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="177">The maximum size allocated to the child.
+
+It is the width if the clamp is horizontal, or the height if it is vertical.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="tightening-threshold"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_tightening_threshold"
+                getter="get_tightening_threshold">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_get_tightening_threshold"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_set_tightening_threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp.c"
+             line="193">The size above which the child is clamped.
+
+Starting from this size, the clamp will tighten its grip on the child,
+slowly allocating less and less of the available size up to the maximum
+allocated size. Below that threshold and below the maximum size, the child
+will be allocated all the available size.
+
+If the threshold is greater than the maximum size to allocate to the child,
+the child will be allocated all the size up to the maximum.
+If the threshold is lower than the minimum size to allocate to the child,
+that size will be used as the tightening threshold.
+
+Effectively, tightening the grip on the child before it reaches its maximum
+size makes transitions to and from the maximum size smoother when resizing.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+    </class>
+    <record name="ClampClass"
+            c:type="AdwClampClass"
+            glib:is-gtype-struct-for="Clamp">
+      <source-position filename="../src/adw-clamp.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="ClampLayout"
+           c:symbol-prefix="clamp_layout"
+           c:type="AdwClampLayout"
+           version="1.0"
+           parent="Gtk.LayoutManager"
+           glib:type-name="AdwClampLayout"
+           glib:get-type="adw_clamp_layout_get_type"
+           glib:type-struct="ClampLayoutClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-clamp-layout.c"
+           line="15">A layout manager constraining its children to a given size.
+
+`AdwClampLayout` constraints the size of the widgets it contains to a given
+maximum size. It will constrain the width if it is horizontal, or the height
+if it is vertical. The expansion of the children from their minimum to their
+maximum size is eased out for a smooth transition.
+
+If a child requires more than the requested maximum size, it will be
+allocated the minimum size it can fit in instead.
+
+Each child will get the style  classes .large when it reached its maximum
+size, .small when it's allocated the full size, .medium in-between, or none
+if it hasn't been allocated yet.</doc>
+      <source-position filename="../src/adw-clamp-layout.h" line="22"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new"
+                   c:identifier="adw_clamp_layout_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="358">Creates a new `AdwClampLayout`.</doc>
+        <source-position filename="../src/adw-clamp-layout.h" line="25"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-layout.c"
+               line="363">the newly created `AdwClampLayout`</doc>
+          <type name="Gtk.LayoutManager" c:type="GtkLayoutManager*"/>
+        </return-value>
+      </constructor>
+      <method name="get_maximum_size"
+              c:identifier="adw_clamp_layout_get_maximum_size"
+              glib:get-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="373">Gets the maximum size allocated to the children.</doc>
+        <source-position filename="../src/adw-clamp-layout.h" line="28"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-layout.c"
+               line="379">the maximum size to allocate to the children</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="375">a `AdwClampLayout`</doc>
+            <type name="ClampLayout" c:type="AdwClampLayout*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tightening_threshold"
+              c:identifier="adw_clamp_layout_get_tightening_threshold"
+              glib:get-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="416">Gets the size above which the children are clamped.</doc>
+        <source-position filename="../src/adw-clamp-layout.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-layout.c"
+               line="422">the size above which the children are clamped</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="418">a `AdwClampLayout`</doc>
+            <type name="ClampLayout" c:type="AdwClampLayout*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_maximum_size"
+              c:identifier="adw_clamp_layout_set_maximum_size"
+              glib:set-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="391">Sets the maximum size allocated to the children.</doc>
+        <source-position filename="../src/adw-clamp-layout.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="393">a `AdwClampLayout`</doc>
+            <type name="ClampLayout" c:type="AdwClampLayout*"/>
+          </instance-parameter>
+          <parameter name="maximum_size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="394">the maximum size</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tightening_threshold"
+              c:identifier="adw_clamp_layout_set_tightening_threshold"
+              glib:set-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="434">Sets the size above which the children are clamped.</doc>
+        <source-position filename="../src/adw-clamp-layout.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="436">a `AdwClampLayout`</doc>
+            <type name="ClampLayout" c:type="AdwClampLayout*"/>
+          </instance-parameter>
+          <parameter name="tightening_threshold" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-layout.c"
+                 line="437">the tightening threshold</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="maximum-size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_maximum_size"
+                getter="get_maximum_size">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_layout_get_maximum_size"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_layout_set_maximum_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="306">The maximum size to allocate to the children. It is the width if the
+layout is horizontal, or the height if it is vertical.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="tightening-threshold"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_tightening_threshold"
+                getter="get_tightening_threshold">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_layout_get_tightening_threshold"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_layout_set_tightening_threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-layout.c"
+             line="321">The size above which the child is clamped.
+
+Starting from this size, the layout will tighten its grip on the children,
+slowly allocating less and less of the available size up to the maximum
+allocated size. Below that threshold and below the maximum size, the
+children will be allocated all the available size.
+
+If the threshold is greater than the maximum size to allocate to the
+children, they will be allocated the whole size up to the maximum. If the
+threshold is lower than the minimum size to allocate to the children, that
+size will be used as the tightening threshold.
+
+Effectively, tightening the grip on a child before it reaches its maximum
+size makes transitions to and from the maximum size smoother when resizing.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+    </class>
+    <record name="ClampLayoutClass"
+            c:type="AdwClampLayoutClass"
+            glib:is-gtype-struct-for="ClampLayout">
+      <source-position filename="../src/adw-clamp-layout.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.LayoutManagerClass" c:type="GtkLayoutManagerClass"/>
+      </field>
+    </record>
+    <class name="ClampScrollable"
+           c:symbol-prefix="clamp_scrollable"
+           c:type="AdwClampScrollable"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwClampScrollable"
+           glib:get-type="adw_clamp_scrollable_get_type"
+           glib:type-struct="ClampScrollableClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-clamp-scrollable.c"
+           line="13">A scrollable [class@Adw.Clamp].
+
+`AdwClampScrollable` is a variant of [class@Adw.Clamp] that implements the
+[iface@Gtk.Scrollable] interface.
+
+The primary use case for `AdwClampScrollable` is clamping
+[class@Gtk.ListView].</doc>
+      <source-position filename="../src/adw-clamp-scrollable.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <implements name="Gtk.Scrollable"/>
+      <constructor name="new"
+                   c:identifier="adw_clamp_scrollable_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="343">Creates a new `AdwClampScrollable`.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-scrollable.c"
+               line="348">the newly created `AdwClampScrollable`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_child"
+              c:identifier="adw_clamp_scrollable_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="358">Gets the child widget of @self.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="28"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-scrollable.c"
+               line="364">the child widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="360">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_maximum_size"
+              c:identifier="adw_clamp_scrollable_get_maximum_size"
+              glib:get-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="430">Gets the maximum size allocated to the child.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-scrollable.c"
+               line="436">the maximum size to allocate to the child</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="432">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tightening_threshold"
+              c:identifier="adw_clamp_scrollable_get_tightening_threshold"
+              glib:get-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="479">Gets the size above which the child is clamped.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-clamp-scrollable.c"
+               line="485">the size above which the child is clamped</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="481">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_child"
+              c:identifier="adw_clamp_scrollable_set_child"
+              glib:set-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="376">Sets the child widget of @self.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="378">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+          <parameter name="child"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="379">the child widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_maximum_size"
+              c:identifier="adw_clamp_scrollable_set_maximum_size"
+              glib:set-property="maximum-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="maximum-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="452">Sets the maximum size allocated to the child.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="454">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+          <parameter name="maximum_size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="455">the maximum size</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tightening_threshold"
+              c:identifier="adw_clamp_scrollable_set_tightening_threshold"
+              glib:set-property="tightening-threshold"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="tightening-threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="501">Sets the size above which the child is clamped.</doc>
+        <source-position filename="../src/adw-clamp-scrollable.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="503">a `AdwClampScrollable`</doc>
+            <type name="ClampScrollable" c:type="AdwClampScrollable*"/>
+          </instance-parameter>
+          <parameter name="tightening_threshold" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-clamp-scrollable.c"
+                 line="504">the tightening threshold</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_scrollable_get_child"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_scrollable_set_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="255">The child widget of the `AdwClampScrollable`.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="maximum-size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_maximum_size"
+                getter="get_maximum_size">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_scrollable_get_maximum_size"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_scrollable_set_maximum_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="269">The maximum size allocated to the child.
+
+It is the width if the clamp is horizontal, or the height if it is vertical.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="tightening-threshold"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_tightening_threshold"
+                getter="get_tightening_threshold">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_clamp_scrollable_get_tightening_threshold"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_clamp_scrollable_set_tightening_threshold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-clamp-scrollable.c"
+             line="285">The size above which the child is clamped.
+
+Starting from this size, the clamp will tighten its grip on the child,
+slowly allocating less and less of the available size up to the maximum
+allocated size. Below that threshold and below the maximum width, the child
+will be allocated all the available size.
+
+If the threshold is greater than the maximum size to allocate to the child,
+the child will be allocated all the width up to the maximum.
+If the threshold is lower than the minimum size to allocate to the child,
+that size will be used as the tightening threshold.
+
+Effectively, tightening the grip on the child before it reaches its maximum
+size makes transitions to and from the maximum size smoother when resizing.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+    </class>
+    <record name="ClampScrollableClass"
+            c:type="AdwClampScrollableClass"
+            glib:is-gtype-struct-for="ClampScrollable">
+      <source-position filename="../src/adw-clamp-scrollable.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <enumeration name="ColorScheme"
+                 version="1.0"
+                 glib:type-name="AdwColorScheme"
+                 glib:get-type="adw_color_scheme_get_type"
+                 c:type="AdwColorScheme">
+      <doc xml:space="preserve"
+           filename="../src/adw-style-manager.c"
+           line="18">Application color schemes for [property@Adw.StyleManager:color-scheme].</doc>
+      <member name="default"
+              value="0"
+              c:identifier="ADW_COLOR_SCHEME_DEFAULT"
+              glib:nick="default"
+              glib:name="ADW_COLOR_SCHEME_DEFAULT">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="20">Inherit the parent color-scheme. When set on the
+  `AdwStyleManager` returned by [func@Adw.StyleManager.get_default], it's
+  equivalent to `ADW_COLOR_SCHEME_PREFER_LIGHT`.</doc>
+      </member>
+      <member name="force_light"
+              value="1"
+              c:identifier="ADW_COLOR_SCHEME_FORCE_LIGHT"
+              glib:nick="force-light"
+              glib:name="ADW_COLOR_SCHEME_FORCE_LIGHT">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="23">Always use light appearance.</doc>
+      </member>
+      <member name="prefer_light"
+              value="2"
+              c:identifier="ADW_COLOR_SCHEME_PREFER_LIGHT"
+              glib:nick="prefer-light"
+              glib:name="ADW_COLOR_SCHEME_PREFER_LIGHT">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="24">Use light appearance unless the system
+  prefers dark colors.</doc>
+      </member>
+      <member name="prefer_dark"
+              value="3"
+              c:identifier="ADW_COLOR_SCHEME_PREFER_DARK"
+              glib:nick="prefer-dark"
+              glib:name="ADW_COLOR_SCHEME_PREFER_DARK">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="26">Use dark appearance unless the system prefers
+  prefers light colors.</doc>
+      </member>
+      <member name="force_dark"
+              value="4"
+              c:identifier="ADW_COLOR_SCHEME_FORCE_DARK"
+              glib:nick="force-dark"
+              glib:name="ADW_COLOR_SCHEME_FORCE_DARK">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="28">Always use dark appearance.</doc>
+      </member>
+    </enumeration>
+    <class name="ComboRow"
+           c:symbol-prefix="combo_row"
+           c:type="AdwComboRow"
+           version="1.0"
+           parent="ActionRow"
+           glib:type-name="AdwComboRow"
+           glib:get-type="adw_combo_row_get_type"
+           glib:type-struct="ComboRowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-combo-row.c"
+           line="16">A [class@Gtk.ListBoxRow] used to choose from a list of items.
+
+The `AdwComboRow` widget allows the user to choose from a list of valid
+choices. The row displays the selected choice. When activated, the row
+displays a popover which allows the user to make a new choice.
+
+`AdwComboRow` mirrors [class@Gtk.DropDown], see that widget for details.
+
+`AdwComboRow` is [property@Gtk.ListBoxRow:activatable] if a model is set.
+
+## CSS nodes
+
+`AdwComboRow` has a main CSS node with name `row` and the `.combo` style
+class.
+
+Its popover has the node named `popover` with the `.combo` style class, it
+contains a [class@Gtk.ScrolledWindow], which in turn contains a
+[class@Gtk.ListView], both are accessible via their regular nodes.
+
+## Accessibility
+
+`AdwComboRow` uses the `GTK_ACCESSIBLE_ROLE_COMBO_BOX` role.</doc>
+      <source-position filename="../src/adw-combo-row.h" line="35"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_combo_row_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="545">Creates a new `AdwComboRow`.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="550">the newly created `AdwComboRow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_expression"
+              c:identifier="adw_combo_row_get_expression"
+              glib:get-property="expression"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="expression"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="831">Gets the expression used to obtain strings from items.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="68"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="837">the expression used to obtain strings from items</doc>
+          <type name="Gtk.Expression" c:type="GtkExpression*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="833">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_factory"
+              c:identifier="adw_combo_row_get_factory"
+              glib:get-property="factory"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="725">Gets the factory that's currently used to populate list items.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="56"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="731">the factory in use</doc>
+          <type name="Gtk.ListItemFactory" c:type="GtkListItemFactory*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="727">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_list_factory"
+              c:identifier="adw_combo_row_get_list_factory"
+              glib:get-property="list-factory"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="list-factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="778">Gets the factory that's currently used to populate list items in the popup.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="62"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="784">the factory in use</doc>
+          <type name="Gtk.ListItemFactory" c:type="GtkListItemFactory*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="780">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_model"
+              c:identifier="adw_combo_row_get_model"
+              glib:get-property="model"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="639">Gets the model that provides the displayed items.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="41"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="645">The model in use</doc>
+          <type name="Gio.ListModel" c:type="GListModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="641">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_selected"
+              c:identifier="adw_combo_row_get_selected"
+              glib:get-property="selected"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="selected"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="588">Gets the position of the selected item.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="47"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="594">the position of the selected item, or `GTK_INVALID_LIST_POSITION`
+  if no item is selected</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="590">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_selected_item"
+              c:identifier="adw_combo_row_get_selected_item"
+              glib:get-property="selected-item"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="selected-item"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="614">Gets the selected item.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="53"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="620">the selected item</doc>
+          <type name="GObject.Object" c:type="gpointer"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="616">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_subtitle"
+              c:identifier="adw_combo_row_get_use_subtitle"
+              glib:get-property="use-subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="use-subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="890">Gets whether to use the current value as the subtitle.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="74"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-combo-row.c"
+               line="896">whether to use the current value as the subtitle</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="892">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_expression"
+              c:identifier="adw_combo_row_set_expression"
+              glib:set-property="expression"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="expression"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="853">Sets the expression used to obtain strings from items.
+
+The expression must have a value type of `G_TYPE_STRING`.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="70"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="855">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="expression"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="856">an expression</doc>
+            <type name="Gtk.Expression" c:type="GtkExpression*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_factory"
+              c:identifier="adw_combo_row_set_factory"
+              glib:set-property="factory"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="747">Sets the `GtkListItemFactory` to use for populating list items.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="58"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="749">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="factory"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="750">the factory to use</doc>
+            <type name="Gtk.ListItemFactory" c:type="GtkListItemFactory*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_list_factory"
+              c:identifier="adw_combo_row_set_list_factory"
+              glib:set-property="list-factory"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="list-factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="800">Sets the `GtkListItemFactory` to use for populating list items in the popup.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="802">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="factory"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="803">the factory to use</doc>
+            <type name="Gtk.ListItemFactory" c:type="GtkListItemFactory*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_model"
+              c:identifier="adw_combo_row_set_model"
+              glib:set-property="model"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="661">Sets the [iface@Gio.ListModel] to use.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="43"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="663">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="model"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="664">the model to use</doc>
+            <type name="Gio.ListModel" c:type="GListModel*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_selected"
+              c:identifier="adw_combo_row_set_selected"
+              glib:set-property="selected"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="selected"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="560">Selects the item at the given position.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="49"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="562">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="563">the position of the item to select, or `GTK_INVALID_LIST_POSITION`</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_subtitle"
+              c:identifier="adw_combo_row_set_use_subtitle"
+              glib:set-property="use-subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="912">Sets whether to use the current value as the subtitle.</doc>
+        <source-position filename="../src/adw-combo-row.h" line="76"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="914">a `AdwComboRow`</doc>
+            <type name="ComboRow" c:type="AdwComboRow*"/>
+          </instance-parameter>
+          <parameter name="use_subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-combo-row.c"
+                 line="915">whether to use the current value as the subtitle</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="expression"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_expression"
+                getter="get_expression">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_expression"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_expression"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="485">An expression used to obtain strings from items.
+
+It's used to bind strings to labels produced by the default factory.
+
+If [property@Adw.ComboRow:factory] is not set, the expression is also
+used to bind strings to labels produced by a default factory.</doc>
+        <type name="Gtk.Expression"/>
+      </property>
+      <property name="factory"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_factory"
+                getter="get_factory">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_factory"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="452">Factory for populating list items.
+
+This factory is always used for the item in the row. It is also used for
+items in the popup unless [property@Adw.ComboRow:list-factory] is set.</doc>
+        <type name="Gtk.ListItemFactory"/>
+      </property>
+      <property name="list-factory"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_list_factory"
+                getter="get_list_factory">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_list_factory"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_list_factory"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="469">The factory for populating list items in the popup.
+
+If this is not set, [property@Adw.ComboRow:factory] is used.</doc>
+        <type name="Gtk.ListItemFactory"/>
+      </property>
+      <property name="model"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_model"
+                getter="get_model">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_model"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="407">Model for the displayed items.</doc>
+        <type name="Gio.ListModel"/>
+      </property>
+      <property name="selected"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_selected"
+                getter="get_selected">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_selected"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_selected"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="421">The position of the selected item.
+
+If no item is selected, the property has the value
+`GTK_INVALID_LIST_POSITION`.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="selected-item"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_selected_item">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_selected_item"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="438">The selected item.</doc>
+        <type name="GObject.Object"/>
+      </property>
+      <property name="use-subtitle"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_subtitle"
+                getter="get_use_subtitle">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_combo_row_get_use_subtitle"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_combo_row_set_use_subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.c"
+             line="503">Whether to use the current value as the subtitle.
+
+If you use a custom list item factory, you will need to give the row a
+name conversion expression with [property@Adw.ComboRow:expression].
+
+If `TRUE`, you should not access [property@Adw.ActionRow:subtitle].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent_instance">
+        <type name="ActionRow" c:type="AdwActionRow"/>
+      </field>
+    </class>
+    <record name="ComboRowClass"
+            c:type="AdwComboRowClass"
+            glib:is-gtype-struct-for="ComboRow">
+      <source-position filename="../src/adw-combo-row.h" line="35"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-combo-row.h"
+             line="27">The parent class</doc>
+        <type name="ActionRowClass" c:type="AdwActionRowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <function-macro name="ENCODE_VERSION"
+                    c:identifier="ADW_ENCODE_VERSION"
+                    introspectable="0">
+      <source-position filename="../src/adw-version.h" line="53"/>
+      <parameters>
+        <parameter name="major">
+        </parameter>
+        <parameter name="minor">
+        </parameter>
+        <parameter name="micro">
+        </parameter>
+      </parameters>
+    </function-macro>
+    <class name="EnumListItem"
+           c:symbol-prefix="enum_list_item"
+           c:type="AdwEnumListItem"
+           version="1.0"
+           parent="GObject.Object"
+           glib:type-name="AdwEnumListItem"
+           glib:get-type="adw_enum_list_item_get_type"
+           glib:type-struct="EnumListItemClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-enum-list-model.c"
+           line="46">`AdwEnumListItem` is the type of items in a [class@Adw.EnumListModel].</doc>
+      <source-position filename="../src/adw-enum-list-model.h" line="22"/>
+      <method name="get_name"
+              c:identifier="adw_enum_list_item_get_name"
+              glib:get-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="180">Gets the enum value name.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="28"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-enum-list-model.c"
+               line="185">the enum value name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="EnumListItem" c:type="AdwEnumListItem*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_nick"
+              c:identifier="adw_enum_list_item_get_nick"
+              glib:get-property="nick"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="nick"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="197">Gets the enum value nick.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="31"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-enum-list-model.c"
+               line="202">the enum value nick</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="EnumListItem" c:type="AdwEnumListItem*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_value"
+              c:identifier="adw_enum_list_item_get_value"
+              glib:get-property="value"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="value"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="163">Gets the enum value.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-enum-list-model.c"
+               line="168">the enum value</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="EnumListItem" c:type="AdwEnumListItem*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="name"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_enum_list_item_get_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="117">The enum value name.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="nick"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_nick">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_enum_list_item_get_nick"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="131">The enum value nick.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="value"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_value">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_enum_list_item_get_value"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="103">The enum value.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+    </class>
+    <record name="EnumListItemClass"
+            c:type="AdwEnumListItemClass"
+            glib:is-gtype-struct-for="EnumListItem">
+      <source-position filename="../src/adw-enum-list-model.h" line="22"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <class name="EnumListModel"
+           c:symbol-prefix="enum_list_model"
+           c:type="AdwEnumListModel"
+           version="1.0"
+           parent="GObject.Object"
+           glib:type-name="AdwEnumListModel"
+           glib:get-type="adw_enum_list_model_get_type"
+           glib:type-struct="EnumListModelClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-enum-list-model.c"
+           line="13">A [iface@Gio.ListModel] representing values of a given enum.
+
+`AdwEnumListModel` contains objects of type [class@AdwEnumListItem].</doc>
+      <source-position filename="../src/adw-enum-list-model.h" line="36"/>
+      <implements name="Gio.ListModel"/>
+      <constructor name="new"
+                   c:identifier="adw_enum_list_model_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="341">Creates a new `AdwEnumListModel` for @enum_type.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="39"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-enum-list-model.c"
+               line="347">the newly created `AdwEnumListModel`</doc>
+          <type name="EnumListModel" c:type="AdwEnumListModel*"/>
+        </return-value>
+        <parameters>
+          <parameter name="enum_type" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-enum-list-model.c"
+                 line="343">the type of the enum to construct the model from</doc>
+            <type name="GType" c:type="GType"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="find_position"
+              c:identifier="adw_enum_list_model_find_position"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="376">Finds the position of a given enum value in @self.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="45"/>
+        <return-value transfer-ownership="none">
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="EnumListModel" c:type="AdwEnumListModel*"/>
+          </instance-parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-enum-list-model.c"
+                 line="378">an enum value</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_enum_type"
+              c:identifier="adw_enum_list_model_get_enum_type"
+              glib:get-property="enum-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="enum-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="359">Gets the type of the enum represented by @self.</doc>
+        <source-position filename="../src/adw-enum-list-model.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-enum-list-model.c"
+               line="364">the enum type</doc>
+          <type name="GType" c:type="GType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="EnumListModel" c:type="AdwEnumListModel*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <property name="enum-type"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_enum_type">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_enum_list_model_get_enum_type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-enum-list-model.c"
+             line="285">The type of the enum represented by the model.</doc>
+        <type name="GType" c:type="GType"/>
+      </property>
+    </class>
+    <record name="EnumListModelClass"
+            c:type="AdwEnumListModelClass"
+            glib:is-gtype-struct-for="EnumListModel">
+      <source-position filename="../src/adw-enum-list-model.h" line="36"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <class name="ExpanderRow"
+           c:symbol-prefix="expander_row"
+           c:type="AdwExpanderRow"
+           version="1.0"
+           parent="PreferencesRow"
+           glib:type-name="AdwExpanderRow"
+           glib:get-type="adw_expander_row_get_type"
+           glib:type-struct="ExpanderRowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-expander-row.c"
+           line="13">A [class@Gtk.ListBoxRow] used to reveal widgets.
+
+The `AdwExpanderRow` widget allows the user to reveal or hide widgets below
+it. It also allows the user to enable the expansion of the row, allowing to
+disable all that the row contains.
+
+## AdwExpanderRow as GtkBuildable
+
+The `AdwExpanderRow` implementation of the [iface@Gtk.Buildable] interface
+supports adding a child as an action widget by specifying “action” as the
+“type” attribute of a &lt;child&gt; element.
+
+It also supports adding it as a prefix widget by specifying “prefix” as the
+“type” attribute of a &lt;child&gt; element.
+
+## CSS nodes
+
+`AdwExpanderRow` has a main CSS node with name `row` and the `.expander`
+style class. It has the `.empty` style class when it contains no children.
+
+It contains the subnodes `row.header` for its main embedded row,
+`list.nested` for the list it can expand, and `image.expander-row-arrow` for
+its arrow.</doc>
+      <source-position filename="../src/adw-expander-row.h" line="35"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_expander_row_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="291">Creates a new `AdwExpanderRow`.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="296">the newly created `AdwExpanderRow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add_action"
+              c:identifier="adw_expander_row_add_action"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="554">Adds an action widget to @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="71"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="556">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="557">a widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_prefix"
+              c:identifier="adw_expander_row_add_prefix"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="578">Adds a prefix widget to @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="74"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="580">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="widget" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="581">a widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_row"
+              c:identifier="adw_expander_row_add_row"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="605">Adds a widget to @self.
+
+The widget will appear in the expanding list below @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="607">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="608">a widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_enable_expansion"
+              c:identifier="adw_expander_row_get_enable_expansion"
+              glib:get-property="enable-expansion"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="enable-expansion"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="450">Gets whether the expansion of @self is enabled.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="59"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="456">whether the expansion of @self is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="452">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_expanded"
+              c:identifier="adw_expander_row_get_expanded"
+              glib:get-property="expanded"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="expanded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="394">Gets whether @self is expanded.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="53"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="400">whether @self is expanded</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="396">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_expander_row_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="350">Gets the icon name for @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="47"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="356">the icon name for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="352">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_enable_switch"
+              c:identifier="adw_expander_row_get_show_enable_switch"
+              glib:get-property="show-enable-switch"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="show-enable-switch"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="503">Gets whether the switch enabling the expansion of @self is visible.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="65"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="509">whether the switch enabling the expansion is visible</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="505">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_subtitle"
+              c:identifier="adw_expander_row_get_subtitle"
+              glib:get-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="306">Gets the subtitle for @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="41"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-expander-row.c"
+               line="312">the subtitle for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="308">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_expander_row_remove">
+        <source-position filename="../src/adw-expander-row.h" line="81"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_enable_expansion"
+              c:identifier="adw_expander_row_set_enable_expansion"
+              glib:set-property="enable-expansion"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="enable-expansion"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="472">Sets whether the expansion of @self is enabled.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="61"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="474">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="enable_expansion" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="475">whether to enable the expansion</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_expanded"
+              c:identifier="adw_expander_row_set_expanded"
+              glib:set-property="expanded"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="expanded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="416">Sets whether @self is expanded.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="55"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="418">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="expanded" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="419">whether to expand the row</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_expander_row_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="372">Sets the icon name for @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="49"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="374">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="375">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_enable_switch"
+              c:identifier="adw_expander_row_set_show_enable_switch"
+              glib:set-property="show-enable-switch"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="show-enable-switch"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="525">Sets whether the switch enabling the expansion of @self is visible.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="67"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="527">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="show_enable_switch" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="528">whether to show the switch enabling the expansion</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_subtitle"
+              c:identifier="adw_expander_row_set_subtitle"
+              glib:set-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="328">Sets the subtitle for @self.</doc>
+        <source-position filename="../src/adw-expander-row.h" line="43"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="330">a `AdwExpanderRow`</doc>
+            <type name="ExpanderRow" c:type="AdwExpanderRow*"/>
+          </instance-parameter>
+          <parameter name="subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-expander-row.c"
+                 line="331">the subtitle</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="enable-expansion"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_enable_expansion"
+                getter="get_enable_expansion">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_expander_row_get_enable_expansion"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_expander_row_set_enable_expansion"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="196">Whether expansion is enabled.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="expanded"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_expanded"
+                getter="get_expanded">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_expander_row_get_expanded"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_expander_row_set_expanded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="182">Whether the row is expanded.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_expander_row_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_expander_row_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="168">The icon name for this row.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="show-enable-switch"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_show_enable_switch"
+                getter="get_show_enable_switch">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_expander_row_get_show_enable_switch"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_expander_row_set_show_enable_switch"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="210">Whether the switch enabling the expansion is visible.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="subtitle"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_subtitle"
+                getter="get_subtitle">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_expander_row_get_subtitle"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_expander_row_set_subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.c"
+             line="154">The subtitle for this row.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent_instance">
+        <type name="PreferencesRow" c:type="AdwPreferencesRow"/>
+      </field>
+    </class>
+    <record name="ExpanderRowClass"
+            c:type="AdwExpanderRowClass"
+            glib:is-gtype-struct-for="ExpanderRow">
+      <source-position filename="../src/adw-expander-row.h" line="35"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-expander-row.h"
+             line="27">The parent class</doc>
+        <type name="PreferencesRowClass" c:type="AdwPreferencesRowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="Flap"
+           c:symbol-prefix="flap"
+           c:type="AdwFlap"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwFlap"
+           glib:get-type="adw_flap_get_type"
+           glib:type-struct="FlapClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-flap.c"
+           line="21">An adaptive container acting like a box or an overlay.
+
+The `AdwFlap` widget can display its children like a [class@Gtk.Box] does or
+like a [class@Gtk.Overlay] does, according to the
+[property@Adw.Flap:fold-policy] value.
+
+`AdwFlap` has at most three children: [property@Adw.Flap:content],
+[property@Adw.Flap:flap] and [property@Adw.Flap:separator]. Content is the
+primary child, flap is displayed next to it when unfolded, or overlays it
+when folded. Flap can be shown or hidden by changing th
+[property@Adw.Flap:reveal-flap] value, as well as via swipe gestures if
+[property@Adw.Flap:swipe-to-open] and/or [property@Adw.Flap:swipe-to-close] are
+set to `TRUE`.
+
+Optionally, a separator can be provided, which would be displayed between
+the content and the flap when there's no shadow to separate them, depending
+on the transition type.
+
+[property@Adw.Flap:flap] is transparent by default; add the `.background`
+style class to it if this is unwanted.
+
+If [property@Adw.Flap:modal] is set to `TRUE`, content becomes completely
+inaccessible when the flap is revealed while folded.
+
+The position of the flap and separator children relative to the content is
+determined by orientation, as well as the [property@Adw.Flap:flap-position]
+value.
+
+Folding the flap will automatically hide the flap widget, and unfolding it
+will automatically reveal it. If this behavior is not desired, the
+[property@Adw.Flap:locked] property can be used to override it.
+
+Common use cases include sidebars, header bars that need to be able to
+overlap the window content (for example, in fullscreen mode) and bottom
+sheets.
+
+## AdwFlap as GtkBuildable
+
+The `AdwFlap` implementation of the [iface@Gtk.Buildable] interface supports
+setting the flap child by specifying “flap” as the “type” attribute of a
+&lt;child&gt; element, and separator by specifying “separator”. Specifying
+“content” child type or omitting it results in setting the content child.
+
+## CSS nodes
+
+`AdwFlap` has a single CSS node with name `flap`. The node will get the style
+classes `.folded` when it is folded, and `.unfolded` when it's not.</doc>
+      <source-position filename="../src/adw-flap.h" line="24"/>
+      <implements name="Swipeable"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new" c:identifier="adw_flap_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1801">Creates a new `AdwFlap`.</doc>
+        <source-position filename="../src/adw-flap.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="1806">the newly created `AdwFlap`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_content"
+              c:identifier="adw_flap_get_content"
+              glib:get-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1816">Gets the content widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="42"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="1822">the content widget for @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1818">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_flap"
+              c:identifier="adw_flap_get_flap"
+              glib:get-property="flap"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1866">Gets the flap widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="48"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="1872">the flap widget for @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1868">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_flap_position"
+              c:identifier="adw_flap_get_flap_position"
+              glib:get-property="flap-position"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="flap-position"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1967">Gets the flap position for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="1973">the flap position for @self</doc>
+          <type name="Gtk.PackType" c:type="GtkPackType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1969">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_fold_duration"
+              c:identifier="adw_flap_get_fold_duration"
+              glib:get-property="fold-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="fold-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2166">Gets the duration that fold transitions in @self will take.</doc>
+        <source-position filename="../src/adw-flap.h" line="87"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2172">the fold transition duration</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2168">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_fold_policy"
+              c:identifier="adw_flap_get_fold_policy"
+              glib:get-property="fold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="fold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2107">Gets the fold policy for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="81"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2113">the fold policy for @self</doc>
+          <type name="FlapFoldPolicy" c:type="AdwFlapFoldPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2109">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_fold_threshold_policy"
+              c:identifier="adw_flap_get_fold_threshold_policy"
+              glib:get-property="fold-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="fold-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2453">Gets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="126"/>
+        <return-value transfer-ownership="none">
+          <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2455">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_folded"
+              c:identifier="adw_flap_get_folded"
+              glib:get-property="folded"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="folded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2207">Gets whether @self is currently folded.</doc>
+        <source-position filename="../src/adw-flap.h" line="93"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2213">`TRUE` if @self is currently folded</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2209">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_locked"
+              c:identifier="adw_flap_get_locked"
+              glib:get-property="locked"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="locked"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2225">Gets whether @self is locked.</doc>
+        <source-position filename="../src/adw-flap.h" line="96"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2231">`TRUE` if @self is locked</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2227">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_modal"
+              c:identifier="adw_flap_get_modal"
+              glib:get-property="modal"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="modal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2315">Gets whether @self is modal.</doc>
+        <source-position filename="../src/adw-flap.h" line="108"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2321">`TRUE` if @self is modal</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2317">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_reveal_duration"
+              c:identifier="adw_flap_get_reveal_duration"
+              glib:get-property="reveal-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reveal-progress"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2048">Returns the duration that reveal transitions in @self will take.</doc>
+        <source-position filename="../src/adw-flap.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2054">the reveal transition duration</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2050">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_reveal_flap"
+              c:identifier="adw_flap_get_reveal_flap"
+              glib:get-property="reveal-flap"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reveal-flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2012">Gets whether the flap widget is revealed for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2018">`TRUE` if the flap widget is revealed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2014">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_reveal_progress"
+              c:identifier="adw_flap_get_reveal_progress"
+              glib:get-property="reveal-progress"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reveal-progress"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2089">Gets the current reveal progress for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2095">the current reveal progress for @self</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2091">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_separator"
+              c:identifier="adw_flap_get_separator"
+              glib:get-property="separator"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="separator"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1917">Gets the separator widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="54"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="1923">the separator widget for @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1919">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_swipe_to_close"
+              c:identifier="adw_flap_get_swipe_to_close"
+              glib:get-property="swipe-to-close"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="swipe-to-close"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2408">Gets whether @self can be closed with a swipe gesture.</doc>
+        <source-position filename="../src/adw-flap.h" line="120"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2414">`TRUE` if @self can be closed with a swipe gesture</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2410">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_swipe_to_open"
+              c:identifier="adw_flap_get_swipe_to_open"
+              glib:get-property="swipe-to-open"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="swipe-to-open"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2363">Gets whether @self can be opened with a swipe gesture.</doc>
+        <source-position filename="../src/adw-flap.h" line="114"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2369">`TRUE` if @self can be opened with a swipe gesture</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2365">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_type"
+              c:identifier="adw_flap_get_transition_type"
+              glib:get-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2268">Gets the type of animation used for reveal and fold transitions in @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-flap.c"
+               line="2274">the current transition type of @self</doc>
+          <type name="FlapTransitionType" c:type="AdwFlapTransitionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2270">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_content"
+              c:identifier="adw_flap_set_content"
+              glib:set-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1834">Sets the content widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1836">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="content"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1837">the content widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_flap"
+              c:identifier="adw_flap_set_flap"
+              glib:set-property="flap"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1884">Sets the flap widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1886">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="flap"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1887">the flap widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_flap_position"
+              c:identifier="adw_flap_set_flap_position"
+              glib:set-property="flap-position"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="flap-position"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1985">Sets the flap position for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="62"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1987">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1988">the new value</doc>
+            <type name="Gtk.PackType" c:type="GtkPackType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_fold_duration"
+              c:identifier="adw_flap_set_fold_duration"
+              glib:set-property="fold-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="fold-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2184">Sets the duration that fold transitions in @self will take.</doc>
+        <source-position filename="../src/adw-flap.h" line="89"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2186">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2187">the new duration, in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_fold_policy"
+              c:identifier="adw_flap_set_fold_policy"
+              glib:set-property="fold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="fold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2125">Sets the fold policy for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="83"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2127">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2128">the fold policy</doc>
+            <type name="FlapFoldPolicy" c:type="AdwFlapFoldPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_fold_threshold_policy"
+              c:identifier="adw_flap_set_fold_threshold_policy"
+              glib:set-property="fold-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="fold-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2470">Sets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="128"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2472">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2473">the policy to use</doc>
+            <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_locked"
+              c:identifier="adw_flap_set_locked"
+              glib:set-property="locked"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="locked"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2243">Sets whether @self is locked.</doc>
+        <source-position filename="../src/adw-flap.h" line="98"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2245">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="locked" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2246">the new value</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_modal"
+              c:identifier="adw_flap_set_modal"
+              glib:set-property="modal"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="modal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2333">Sets whether @self is modal.</doc>
+        <source-position filename="../src/adw-flap.h" line="110"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2335">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="modal" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2336">whether @self is modal</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_reveal_duration"
+              c:identifier="adw_flap_set_reveal_duration"
+              glib:set-property="reveal-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="reveal-progress"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2066">Sets the duration that reveal transitions in @self will take.</doc>
+        <source-position filename="../src/adw-flap.h" line="74"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2068">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2069">the new duration, in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_reveal_flap"
+              c:identifier="adw_flap_set_reveal_flap"
+              glib:set-property="reveal-flap"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="reveal-flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2030">Sets whether the flap widget is revealed for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="68"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2032">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="reveal_flap" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2033">whether to reveal the flap widget</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_separator"
+              c:identifier="adw_flap_set_separator"
+              glib:set-property="separator"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="separator"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1935">Sets the separator widget for @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1937">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="separator"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="1938">the separator widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_swipe_to_close"
+              c:identifier="adw_flap_set_swipe_to_close"
+              glib:set-property="swipe-to-close"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="swipe-to-close"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2426">Sets whether @self can be closed with a swipe gesture.</doc>
+        <source-position filename="../src/adw-flap.h" line="122"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2428">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="swipe_to_close" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2429">whether @self can be closed with a swipe gesture</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_swipe_to_open"
+              c:identifier="adw_flap_set_swipe_to_open"
+              glib:set-property="swipe-to-open"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="swipe-to-open"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2381">Sets whether @self can be opened with a swipe gesture.</doc>
+        <source-position filename="../src/adw-flap.h" line="116"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2383">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="swipe_to_open" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2384">whether @self can be opened with a swipe gesture</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_transition_type"
+              c:identifier="adw_flap_set_transition_type"
+              glib:set-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="2286">Sets the type of animation used for reveal and fold transitions in @self.</doc>
+        <source-position filename="../src/adw-flap.h" line="104"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2288">a `AdwFlap`</doc>
+            <type name="Flap" c:type="AdwFlap*"/>
+          </instance-parameter>
+          <parameter name="transition_type" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-flap.c"
+                 line="2289">the new transition type</doc>
+            <type name="FlapTransitionType" c:type="AdwFlapTransitionType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="content"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_content"
+                getter="get_content">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_content"/>
+        <attribute name="org.gtk.Property.set" value="adw_flap_set_content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1268">The content widget.
+
+It's always displayed when unfolded, and partially visible
+when folded.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="flap"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_flap"
+                getter="get_flap">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_flap"/>
+        <attribute name="org.gtk.Property.set" value="adw_flap_set_flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1285">The flap widget.
+
+It's only visible when [property@Adw.Flap:reveal-progress] is greater than
+0.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="flap-position"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_flap_position"
+                getter="get_flap_position">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_flap_position"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_flap_position"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1320">The flap position.
+
+If it's set to `GTK_PACK_START`, the flap is displayed before the content,
+if `GTK_PACK_END`, it's displayed after the content.</doc>
+        <type name="Gtk.PackType"/>
+      </property>
+      <property name="fold-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_fold_duration"
+                getter="get_fold_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_fold_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_fold_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1422">The fold transition animation duration, in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="fold-policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_fold_policy"
+                getter="get_fold_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_fold_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1385">The fold policy for the flap.</doc>
+        <type name="FlapFoldPolicy"/>
+      </property>
+      <property name="fold-threshold-policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_fold_threshold_policy"
+                getter="get_fold_threshold_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_fold_threshold_policy"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_fold_threshold_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1400">Determines when the flap will fold.
+
+If set to `ADW_FOLD_THRESHOLD_POLICY_MINIMUM`, flap will only fold when
+the children cannot fit anymore. With `ADW_FOLD_THRESHOLD_POLICY_NATURAL`,
+it will fold as soon as children don't get their natural size.
+
+This can be useful if you have a long ellipsizing label and want to let it
+ellipsize instead of immediately folding.</doc>
+        <type name="FoldThresholdPolicy"/>
+      </property>
+      <property name="folded"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_folded">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_folded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1437">Whether the flap is currently folded.
+
+See [property@Adw.Flap:fold-policy].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="locked"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_locked"
+                getter="get_locked">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_locked"/>
+        <attribute name="org.gtk.Property.set" value="adw_flap_set_locked"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1453">Whether the flap is locked.
+
+If `FALSE`, folding when the flap is revealed automatically closes it, and
+unfolding it when the flap is not revealed opens it. If `TRUE`,
+[property@Adw.Flap:reveal-flap] value never changes on its own.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="modal"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_modal"
+                getter="get_modal">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_modal"/>
+        <attribute name="org.gtk.Property.set" value="adw_flap_set_modal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1490">Whether the flap is modal.
+
+If `TRUE`, clicking the content widget while flap is revealed, as well as
+pressing Escape key, will close the flap. If `FALSE`, clicks are passed
+through to the content widget.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="reveal-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_reveal_duration"
+                getter="get_reveal_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_reveal_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_reveal_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1352">The reveal transition animation duration, in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="reveal-flap"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_reveal_flap"
+                getter="get_reveal_flap">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_reveal_flap"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_reveal_flap"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1338">Whether the flap widget is revealed.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="reveal-progress"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_reveal_progress">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_reveal_progress"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1367">The current reveal transition progress.
+
+0 means fully hidden, 1 means fully revealed.
+
+See [property@Adw.Flap:reveal-flap].</doc>
+        <type name="gdouble" c:type="gdouble"/>
+      </property>
+      <property name="separator"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_separator"
+                getter="get_separator">
+        <attribute name="org.gtk.Property.get" value="adw_flap_get_separator"/>
+        <attribute name="org.gtk.Property.set" value="adw_flap_set_separator"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1302">The separator widget.
+
+It's displayed between content and flap when there's no shadow to display.
+When exactly it's visible depends on the
+[property@Adw.Flap:transition-type] value.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="swipe-to-close"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_swipe_to_close"
+                getter="get_swipe_to_close">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_swipe_to_close"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_swipe_to_close"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1525">Whether the flap can be closed with a swipe gesture.
+
+The area that can be swiped depends on the
+[property@Adw.Flap:transition-type] value.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="swipe-to-open"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_swipe_to_open"
+                getter="get_swipe_to_open">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_swipe_to_open"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_swipe_to_open"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1508">Whether the flap can be opened with a swipe gesture.
+
+The area that can be swiped depends on the
+[property@Adw.Flap:transition-type] value.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="transition-type"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_transition_type"
+                getter="get_transition_type">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_flap_get_transition_type"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_flap_set_transition_type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="1471">the type of animation used for reveal and fold transitions.
+
+[property@Adw.Flap:flap] is transparent by default, which means the content
+will be seen through it with `ADW_FLAP_TRANSITION_TYPE_OVER` transitions;
+add the `.background` style class to it if this is unwanted.</doc>
+        <type name="FlapTransitionType"/>
+      </property>
+    </class>
+    <record name="FlapClass"
+            c:type="AdwFlapClass"
+            glib:is-gtype-struct-for="Flap">
+      <source-position filename="../src/adw-flap.h" line="24"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <enumeration name="FlapFoldPolicy"
+                 version="1.0"
+                 glib:type-name="AdwFlapFoldPolicy"
+                 glib:get-type="adw_flap_fold_policy_get_type"
+                 c:type="AdwFlapFoldPolicy">
+      <doc xml:space="preserve"
+           filename="../src/adw-flap.c"
+           line="75">Describes the possible folding behavior of a [class@Adw.Flap] widget.</doc>
+      <member name="never"
+              value="0"
+              c:identifier="ADW_FLAP_FOLD_POLICY_NEVER"
+              glib:nick="never"
+              glib:name="ADW_FLAP_FOLD_POLICY_NEVER">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="77">Disable folding, the flap cannot reach narrow
+  sizes.</doc>
+      </member>
+      <member name="always"
+              value="1"
+              c:identifier="ADW_FLAP_FOLD_POLICY_ALWAYS"
+              glib:nick="always"
+              glib:name="ADW_FLAP_FOLD_POLICY_ALWAYS">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="79">Keep the flap always folded.</doc>
+      </member>
+      <member name="auto"
+              value="2"
+              c:identifier="ADW_FLAP_FOLD_POLICY_AUTO"
+              glib:nick="auto"
+              glib:name="ADW_FLAP_FOLD_POLICY_AUTO">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="80">Fold and unfold the flap based on available
+  space.</doc>
+      </member>
+    </enumeration>
+    <enumeration name="FlapTransitionType"
+                 version="1.0"
+                 glib:type-name="AdwFlapTransitionType"
+                 glib:get-type="adw_flap_transition_type_get_type"
+                 c:type="AdwFlapTransitionType">
+      <doc xml:space="preserve"
+           filename="../src/adw-flap.c"
+           line="88">Describes transitions types of a [class@Adw.Flap] widget.
+
+It determines the type of animation when transitioning between children in a
+[class@Adw.Flap] widget, as well as which areas can be swiped via
+[property@Adw.Flap:swipe-to-open] and [property@Adw.Flap:swipe-to-close].
+
+New values may be added to this enum over time.</doc>
+      <member name="over"
+              value="0"
+              c:identifier="ADW_FLAP_TRANSITION_TYPE_OVER"
+              glib:nick="over"
+              glib:name="ADW_FLAP_TRANSITION_TYPE_OVER">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="90">The flap slides over the content, which is
+  dimmed. When folded, only the flap can be swiped.</doc>
+      </member>
+      <member name="under"
+              value="1"
+              c:identifier="ADW_FLAP_TRANSITION_TYPE_UNDER"
+              glib:nick="under"
+              glib:name="ADW_FLAP_TRANSITION_TYPE_UNDER">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="92">The content slides over the flap. Only the
+  content can be swiped.</doc>
+      </member>
+      <member name="slide"
+              value="2"
+              c:identifier="ADW_FLAP_TRANSITION_TYPE_SLIDE"
+              glib:nick="slide"
+              glib:name="ADW_FLAP_TRANSITION_TYPE_SLIDE">
+        <doc xml:space="preserve"
+             filename="../src/adw-flap.c"
+             line="94">The flap slides offscreen when hidden,
+  neither the flap nor content overlap each other. Both widgets can be
+  swiped.</doc>
+      </member>
+    </enumeration>
+    <enumeration name="FoldThresholdPolicy"
+                 version="1.0"
+                 glib:type-name="AdwFoldThresholdPolicy"
+                 glib:get-type="adw_fold_threshold_policy_get_type"
+                 c:type="AdwFoldThresholdPolicy">
+      <doc xml:space="preserve"
+           filename="../src/adw-fold-threshold-policy.c"
+           line="10">Determines when [class@Adw.Flap] and [class@Adw.Leaflet] will fold.</doc>
+      <member name="minimum"
+              value="0"
+              c:identifier="ADW_FOLD_THRESHOLD_POLICY_MINIMUM"
+              glib:nick="minimum"
+              glib:name="ADW_FOLD_THRESHOLD_POLICY_MINIMUM">
+        <doc xml:space="preserve"
+             filename="../src/adw-fold-threshold-policy.c"
+             line="12">Folding is based on the minimum size</doc>
+      </member>
+      <member name="natural"
+              value="1"
+              c:identifier="ADW_FOLD_THRESHOLD_POLICY_NATURAL"
+              glib:nick="natural"
+              glib:name="ADW_FOLD_THRESHOLD_POLICY_NATURAL">
+        <doc xml:space="preserve"
+             filename="../src/adw-fold-threshold-policy.c"
+             line="13">Folding is based on the natural size</doc>
+      </member>
+    </enumeration>
+    <class name="HeaderBar"
+           c:symbol-prefix="header_bar"
+           c:type="AdwHeaderBar"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwHeaderBar"
+           glib:get-type="adw_header_bar_get_type"
+           glib:type-struct="HeaderBarClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-header-bar.c"
+           line="31">A title bar widget.
+
+`AdwHeaderBar` is similar to [class@Gtk.HeaderBar], but provides additional
+features compared to it. Refer to `GtkHeaderBar` for details.
+
+[property@Adw.HeaderBar:centering-policy] allows to enforce strict centering
+of the title widget, this is useful for [class@Adw.ViewSwitcherTitle].
+
+[property@Adw.HeaderBar:show-start-title-buttons] and
+[property@Adw.HeaderBar:show-end-title-buttons] allow to easily create split
+header bar layouts using [class@Adw.Leaflet], as follows:
+
+```xml
+&lt;object class="AdwLeaflet" id="leaflet"&gt;
+  &lt;child&gt;
+    &lt;object class="GtkBox"&gt;
+      &lt;property name="orientation"&gt;vertical&lt;/property&gt;
+      &lt;object class="AdwHeaderBar"&gt;
+        &lt;binding name="show-end-title-buttons"&gt;
+          &lt;lookup name="folded"&gt;leaflet&lt;/lookup&gt;
+        &lt;/binding&gt;
+      &lt;/object&gt;
+      ...
+    &lt;/object&gt;
+  &lt;/child&gt;
+  ...
+  &lt;child&gt;
+    &lt;object class="GtkBox"&gt;
+      &lt;property name="orientation"&gt;vertical&lt;/property&gt;
+      &lt;object class="AdwHeaderBar"&gt;
+        &lt;binding name="show-start-title-buttons"&gt;
+          &lt;lookup name="folded"&gt;leaflet&lt;/lookup&gt;
+        &lt;/binding&gt;
+      &lt;/object&gt;
+      ...
+    &lt;/object&gt;
+  &lt;/child&gt;
+&lt;/object&gt;
+```
+
+## CSS nodes
+
+```
+headerbar
+╰── windowhandle
+    ╰── box
+        ├── widget
+        │   ╰── box.start
+        │       ├── windowcontrols.start
+        │       ╰── [other children]
+        ├── [Title Widget]
+        ╰── widget
+            ╰── box.end
+                ├── [other children]
+                ╰── windowcontrols.end
+```
+
+`AdwHeaderBar`'s CSS node is called `headerbar`. It contains a `windowhandle`
+subnode, which contains a `box` subnode, which contains two `widget` subnodes
+at the start and end of the header bar, each of which contains a `box`
+subnode with the `.start` and `.end` style classes respectively, as well as a
+center node that represents the title.
+
+Each of the boxes contains a `windowcontrols` subnode, see
+[class@Gtk.WindowControls] for details, as well as other children.
+
+## Accessibility
+
+`AdwHeaderBar` uses the %GTK_ACCESSIBLE_ROLE_GROUP role.</doc>
+      <source-position filename="../src/adw-header-bar.h" line="37"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_header_bar_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="559">Creates a new `AdwHeaderBar`.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="45"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="564">the newly created `AdwHeaderBar`.</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_centering_policy"
+              c:identifier="adw_header_bar_get_centering_policy"
+              glib:get-property="centering-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="centering-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="837">Gets the policy for aligning the center widget.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="82"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="843">the centering policy</doc>
+          <type name="CenteringPolicy" c:type="AdwCenteringPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="839">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_decoration_layout"
+              c:identifier="adw_header_bar_get_decoration_layout"
+              glib:get-property="decoration-layout"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="decoration-layout"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="819">Gets the decoration layout for @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="76"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="825">the decoration layout</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="821">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_end_title_buttons"
+              c:identifier="adw_header_bar_get_show_end_title_buttons"
+              glib:get-property="show-end-title-buttons"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="show-end-title-buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="746">Gets whether to show title buttons at the end of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="70"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="752">`TRUE` if title buttons at the end are shown</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="748">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_show_start_title_buttons"
+              c:identifier="adw_header_bar_get_show_start_title_buttons"
+              glib:get-property="show-start-title-buttons"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="show-start-title-buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="694">Gets whether to show title buttons at the start of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="700">`TRUE` if title buttons at the start are shown</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="696">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title_widget"
+              c:identifier="adw_header_bar_get_title_widget"
+              glib:get-property="title-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="643">Gets the title widget widget of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="48"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-header-bar.c"
+               line="649">the title widget</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="645">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="pack_end"
+              c:identifier="adw_header_bar_pack_end"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="590">Adds @child to @self, packed with reference to the end of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="592">A `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="593">the widget to be added to @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="pack_start"
+              c:identifier="adw_header_bar_pack_start"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="574">Adds @child to @self, packed with reference to the start of the @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="576">A `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="577">the widget to be added to @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_header_bar_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="661">Removes a child from @self.
+
+The child must have been added with [method@Adw.HeaderBar.pack_start],
+[method@Adw.HeaderBar.pack_end] or [property@Adw.HeaderBar:title-widget].</doc>
+        <source-position filename="../src/adw-header-bar.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="663">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="664">the child to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_centering_policy"
+              c:identifier="adw_header_bar_set_centering_policy"
+              glib:set-property="centering-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="centering-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="855">Sets the policy for aligning the center widget.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="84"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="857">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="centering_policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="858">the centering policy</doc>
+            <type name="CenteringPolicy" c:type="AdwCenteringPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_decoration_layout"
+              c:identifier="adw_header_bar_set_decoration_layout"
+              glib:set-property="decoration-layout"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="decoration-layout"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="798">Sets the decoration layout for @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="800">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="layout"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="801">a decoration layout, or `NULL` to unset the layout</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_end_title_buttons"
+              c:identifier="adw_header_bar_set_show_end_title_buttons"
+              glib:set-property="show-end-title-buttons"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="show-end-title-buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="764">Sets whether to show title buttons at the end of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="766">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="setting" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="767">`TRUE` to show standard title buttons</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_show_start_title_buttons"
+              c:identifier="adw_header_bar_set_show_start_title_buttons"
+              glib:set-property="show-start-title-buttons"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="show-start-title-buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="712">Sets whether to show title buttons at the start of @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="714">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="setting" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="715">`TRUE` to show standard title buttons</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title_widget"
+              c:identifier="adw_header_bar_set_title_widget"
+              glib:set-property="title-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="606">Sets the title widget for @self.</doc>
+        <source-position filename="../src/adw-header-bar.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="608">a `AdwHeaderBar`</doc>
+            <type name="HeaderBar" c:type="AdwHeaderBar*"/>
+          </instance-parameter>
+          <parameter name="title_widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-header-bar.c"
+                 line="609">a widget to use for a title</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="centering-policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_centering_policy"
+                getter="get_centering_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_header_bar_get_centering_policy"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_header_bar_set_centering_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="468">The policy for aligning the center widget.</doc>
+        <type name="CenteringPolicy"/>
+      </property>
+      <property name="decoration-layout"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_decoration_layout"
+                getter="get_decoration_layout">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_header_bar_get_decoration_layout"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_header_bar_set_decoration_layout"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="443">The decoration layout for buttons.
+
+Ithis property is not set, the
+[property@Gtk.Settings:gtk-decoration-layout] setting is used.
+
+The format of the string is button names, separated by commas. A colon
+separates the buttons that should appear at the start from those at the
+ebd. Recognized button names are minimize, maximize, close and icon (the
+window icon).
+
+For example, “icon:minimize,maximize,close” specifies an icon at the start,
+and minimize, maximize and close buttons at the end.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="show-end-title-buttons"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_show_end_title_buttons"
+                getter="get_show_end_title_buttons">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_header_bar_get_show_end_title_buttons"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_header_bar_set_show_end_title_buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="422">Whether to show title buttons at the end of the header bar.
+
+See [property@Adw.HeaderBar:show-start-title-buttons] for the other side.
+
+Which buttons are actually shown and where is determined by the
+[property@Adw.HeaderBar:decoration-layout] property, and by the state of
+the window (e.g. a close button will not be shown if the window can't be
+closed).</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="show-start-title-buttons"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_show_start_title_buttons"
+                getter="get_show_start_title_buttons">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_header_bar_get_show_start_title_buttons"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_header_bar_set_show_start_title_buttons"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="401">Whether to show title buttons at the start of the header bar.
+
+See [property@Adw.HeaderBar:show-end-title-buttons] for the other side.
+
+Which buttons are actually shown and where is determined by the
+[property@Adw.HeaderBar:decoration-layout] property, and by the state of
+the window (e.g. a close button will not be shown if the window can't be
+closed).</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="title-widget"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title_widget"
+                getter="get_title_widget">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_header_bar_get_title_widget"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_header_bar_set_title_widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-header-bar.c"
+             line="372">The title widget to display.
+
+When set to `NULL`, the header bar will display the title of the window it
+is contained in.
+
+To use a different title, use [class@Adw.WindowTitle]:
+
+```xml
+&lt;object class="AdwHeaderBar"&gt;
+  &lt;property name="title-widget"&gt;
+    &lt;object class="AdwWindowTitle"&gt;
+      &lt;property name="title" translatable="yes"&gt;Title&lt;/property&gt;
+    &lt;/object&gt;
+  &lt;/property&gt;
+&lt;/object&gt;
+```</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+    </class>
+    <record name="HeaderBarClass"
+            c:type="AdwHeaderBarClass"
+            glib:is-gtype-struct-for="HeaderBar">
+      <source-position filename="../src/adw-header-bar.h" line="37"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="Leaflet"
+           c:symbol-prefix="leaflet"
+           c:type="AdwLeaflet"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwLeaflet"
+           glib:get-type="adw_leaflet_get_type"
+           glib:type-struct="LeafletClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-leaflet.c"
+           line="21">An adaptive container acting like a box or a stack.
+
+The `AdwLeaflet` widget can display its children like a [class@Gtk.Box] does
+or like a [class@Gtk.Stack] does, adapting to size changes by switching
+between the two modes.
+
+When there is enough space the children are displayed side by side, otherwise
+only one is displayed and the leaflet is said to be “folded”.
+The threshold is dictated by the preferred minimum sizes of the children.
+When a leaflet is folded, the children can be navigated using swipe gestures.
+
+The “over” and “under” transition types stack the children one on top of the
+other, while the “slide” transition puts the children side by side. While
+navigating to a child on the side or below can be performed by swiping the
+current child away, navigating to an upper child requires dragging it from
+the edge where it resides. This doesn't affect non-dragging swipes.
+
+## CSS nodes
+
+`AdwLeaflet` has a single CSS node with name `leaflet`. The node will get the
+style classes `.folded` when it is folded, `.unfolded` when it's not, or none
+if it hasn't computed its fold yet.</doc>
+      <source-position filename="../src/adw-leaflet.h" line="45"/>
+      <implements name="Swipeable"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new" c:identifier="adw_leaflet_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2770">Creates a new `AdwLeaflet`.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2775">the new created `AdwLeaflet`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="append" c:identifier="adw_leaflet_append" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2785">Adds a child to @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2792">the [class@Adw.LeafletPage] for @child</doc>
+          <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2787">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2788">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_adjacent_child"
+              c:identifier="adw_leaflet_get_adjacent_child"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3405">Finds the previous or next navigatable child.
+
+This will be the same child [method@Adw.Leaflet.navigate] or swipe gestures
+will navigate to.
+
+If there's no child to navigate to, `NULL` will be returned instead.
+
+See [property@Adw.LeafletPage:navigatable].</doc>
+        <source-position filename="../src/adw-leaflet.h" line="135"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3419">the previous or next child</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3407">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3408">the direction</doc>
+            <type name="NavigationDirection" c:type="AdwNavigationDirection"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_can_swipe_back"
+              c:identifier="adw_leaflet_get_can_swipe_back"
+              glib:get-property="can-swipe-back"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="can-swipe-back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3343">Gets whether a swipe gesture can be used to navigate to the previous child.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="123"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3349">whether back swipe is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3345">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_can_swipe_forward"
+              c:identifier="adw_leaflet_get_can_swipe_forward"
+              glib:get-property="can-swipe-forward"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="can-swipe-forward"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3387">Gets whether a swipe gesture can be used to navigate to the next child.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="129"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3393">Whether forward swipe is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3389">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_can_unfold"
+              c:identifier="adw_leaflet_get_can_unfold"
+              glib:get-property="can-unfold"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="can-unfold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3527">Gets whether @self can unfold.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="146"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3533">whether @self can unfold</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3529">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_child_by_name"
+              c:identifier="adw_leaflet_get_child_by_name"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3471">Finds the child of @self with @name.
+
+Returns `NULL` if there is no child with this name.
+
+See [property@Adw.LeafletPage:name].</doc>
+        <source-position filename="../src/adw-leaflet.h" line="142"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3482">the requested child of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3473">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3474">the name of the child to find</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_child_transition_duration"
+              c:identifier="adw_leaflet_get_child_transition_duration"
+              glib:get-property="child-transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="child-transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3158">Gets the child transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="114"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3164">the child transition duration, in milliseconds</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3160">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_child_transition_running"
+              c:identifier="adw_leaflet_get_child_transition_running"
+              glib:get-property="child-transition-running"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="child-transition-running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3298">Gets whether a child transition is currently running for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="120"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3304">whether a transition is currently running</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3300">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_fold_threshold_policy"
+              c:identifier="adw_leaflet_get_fold_threshold_policy"
+              glib:get-property="fold-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="fold-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3573">Gets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="155"/>
+        <return-value transfer-ownership="none">
+          <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3575">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_folded"
+              c:identifier="adw_leaflet_get_folded"
+              glib:get-property="folded"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="folded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2999">Gets whether @self is folded.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="81"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3005">whether @self is folded.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3001">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_homogeneous"
+              c:identifier="adw_leaflet_get_homogeneous"
+              glib:get-property="homogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3017">Gets whether @self is homogeneous.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="84"/>
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3019">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_mode_transition_duration"
+              c:identifier="adw_leaflet_get_mode_transition_duration"
+              glib:get-property="mode-transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="mode-transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3117">Gets the mode transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="108"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3123">the mode transition duration, in milliseconds.</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3119">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_page"
+              c:identifier="adw_leaflet_get_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2978">Returns the [class@Adw.LeafletPage] object for @child.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="77"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2985">the page object for @child</doc>
+          <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2980">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2981">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_pages"
+              c:identifier="adw_leaflet_get_pages"
+              glib:get-property="pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3545">Returns a [iface@Gio.ListModel] that contains the pages of the leaflet.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the visible
+page.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="152"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3555">a `GtkSelectionModel` for the leaflet's children</doc>
+          <type name="Gtk.SelectionModel" c:type="GtkSelectionModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3547">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_type"
+              c:identifier="adw_leaflet_get_transition_type"
+              glib:get-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3063">Gets the type of animation used for transitions between modes and children.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3069">the current transition type of @self</doc>
+          <type name="LeafletTransitionType"
+                c:type="AdwLeafletTransitionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3065">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_child"
+              c:identifier="adw_leaflet_get_visible_child"
+              glib:get-property="visible-child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="visible-child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3199">Gets the widget currently visible when the leaflet is folded.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="90"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3205">the visible child</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3201">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_child_name"
+              c:identifier="adw_leaflet_get_visible_child_name"
+              glib:get-property="visible-child-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="visible-child-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3248">Gets the name of the currently visible child widget.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="96"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3254">the name of the visible child</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3250">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="insert_child_after"
+              c:identifier="adw_leaflet_insert_child_after"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2836">Inserts @child in the position after @sibling in the list of children.
+
+If @sibling is `NULL`, inserts @child at the first position.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2846">the [class@Adw.LeafletPage] for @child</doc>
+          <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2838">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2839">the widget to insert</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="sibling"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2840">the sibling after which to insert @child</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="navigate"
+              c:identifier="adw_leaflet_navigate"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3436">Navigates to the previous or next child.
+
+The child must have the [property@Adw.LeafletPage:navigatable] property set
+to `TRUE`, otherwise it will be skipped.
+
+This will be the same child as returned by
+[method@Adw.Leaflet.get_adjacent_child] or navigated to via swipe gestures.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="138"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="3449">whether the visible child was changed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3438">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3439">the direction</doc>
+            <type name="NavigationDirection" c:type="AdwNavigationDirection"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="prepend" c:identifier="adw_leaflet_prepend" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2814">Inserts @child at the first position in @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2821">the [class@Adw.LeafletPage] for @child</doc>
+          <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2816">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2817">the widget to prepend</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_leaflet_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2945">Removes a child widget from @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="73"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2947">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2948">the child to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_child_after"
+              c:identifier="adw_leaflet_reorder_child_after"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2875">Moves @child to the position after @sibling in the list of children.
+
+If @sibling is `NULL`, moves @child to the first position.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="68"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2877">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2878">the widget to move, must be a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="sibling"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2879">the sibling to move @child after</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_can_swipe_back"
+              c:identifier="adw_leaflet_set_can_swipe_back"
+              glib:set-property="can-swipe-back"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="can-swipe-back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3317">Sets whether a swipe gesture can be used to navigate to the previous child.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="125"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3319">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="can_swipe_back" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3320">the new value</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_can_swipe_forward"
+              c:identifier="adw_leaflet_set_can_swipe_forward"
+              glib:set-property="can-swipe-forward"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="can-swipe-forward"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3361">Sets whether a swipe gesture can be used to navigate to the next child.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="131"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3363">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="can_swipe_forward" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3364">the new value</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_can_unfold"
+              c:identifier="adw_leaflet_set_can_unfold"
+              glib:set-property="can-unfold"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="can-unfold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3500">Sets whether @self can unfold.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="148"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3502">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="can_unfold" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3503">whether @self can unfold</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_child_transition_duration"
+              c:identifier="adw_leaflet_set_child_transition_duration"
+              glib:set-property="child-transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="child-transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3176">Sets the child transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="116"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3178">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3179">the new duration, in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_fold_threshold_policy"
+              c:identifier="adw_leaflet_set_fold_threshold_policy"
+              glib:set-property="fold-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="fold-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3590">Sets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="157"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3592">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3593">the policy to use</doc>
+            <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_homogeneous"
+              c:identifier="adw_leaflet_set_homogeneous"
+              glib:set-property="homogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3033">Sets @self to be homogeneous or not.
+
+If set to `FALSE`, different children can have different size along the
+opposite orientation.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="86"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3035">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="homogeneous" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3036">whether to make @self homogeneous</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_mode_transition_duration"
+              c:identifier="adw_leaflet_set_mode_transition_duration"
+              glib:set-property="mode-transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="mode-transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3135">Sets the mode transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="110"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3137">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3138">the new duration, in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_transition_type"
+              c:identifier="adw_leaflet_set_transition_type"
+              glib:set-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3081">Sets the type of animation used for transitions between modes and children.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="104"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3083">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="transition" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3084">the new transition type</doc>
+            <type name="LeafletTransitionType"
+                  c:type="AdwLeafletTransitionType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_child"
+              c:identifier="adw_leaflet_set_visible_child"
+              glib:set-property="visible-child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="visible-child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3220">Sets the widget currently visible when the leaflet is folded.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="92"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3222">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="visible_child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3223">the new child</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_child_name"
+              c:identifier="adw_leaflet_set_visible_child_name"
+              glib:set-property="visible-child-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="visible-child-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="3269">Makes the child with the name @name visible.
+
+See adw_leaflet_set_visible_child() for more details.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="98"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3271">a `AdwLeaflet`</doc>
+            <type name="Leaflet" c:type="AdwLeaflet*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="3272">the name of a child</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="can-swipe-back"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_can_swipe_back"
+                getter="get_can_swipe_back">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_can_swipe_back"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_can_swipe_back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2348">Whether a swipe gesture can be used to navigate to the previous child.
+
+Only children that have [property@Adw.LeafletPage:navigatable] set to
+`TRUE` can be navigated to.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="can-swipe-forward"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_can_swipe_forward"
+                getter="get_can_swipe_forward">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_can_swipe_forward"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_can_swipe_forward"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2365">Whether a swipe gesture can be used to navigate to the next child.
+
+Only children that have [property@Adw.LeafletPage:navigatable] set to
+`TRUE` can be navigated to.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="can-unfold"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_can_unfold"
+                getter="get_can_unfold">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_can_unfold"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_can_unfold"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2382">Whether or not the leaflet can unfold.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="child-transition-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child_transition_duration"
+                getter="get_child_transition_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_child_transition_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_child_transition_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2320">The child transition animation duration, in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="child-transition-running"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_child_transition_running">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_child_transition_running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2334">Whether a child transition is currently running.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="fold-threshold-policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_fold_threshold_policy"
+                getter="get_fold_threshold_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_fold_threshold_policy"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_fold_threshold_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2214">Determines when the leaflet will fold.
+
+If set to `ADW_FOLD_THRESHOLD_POLICY_MINIMUM`, it will only fold when
+the children cannot fit anymore. With `ADW_FOLD_THRESHOLD_POLICY_NATURAL`,
+it will fold as soon as children don't get their natural size.
+
+This can be useful if you have a long ellipsizing label and want to let it
+ellipsize instead of immediately folding.</doc>
+        <type name="FoldThresholdPolicy"/>
+      </property>
+      <property name="folded"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_folded">
+        <attribute name="org.gtk.Property.get" value="adw_leaflet_get_folded"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2197">Whether the leaflet is folded.
+
+The leaflet will be folded if the size allocated to it is smaller than the
+sum of the fold threshold policy, it will be unfolded otherwise.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="homogeneous"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_homogeneous"
+                getter="get_homogeneous">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_homogeneous"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2236">Whether the leaflet allocates the same size for all children when folded.
+
+If set to `FALSE`, different children can have different size along the
+opposite orientation.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="mode-transition-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_mode_transition_duration"
+                getter="get_mode_transition_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_mode_transition_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_mode_transition_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2306">The mode transition animation duration, in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_pages">
+        <attribute name="org.gtk.Property.get" value="adw_leaflet_get_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2396">A selection model with the leaflet's pages.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the visible
+page.</doc>
+        <type name="Gtk.SelectionModel"/>
+      </property>
+      <property name="transition-type"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_transition_type"
+                getter="get_transition_type">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_transition_type"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_transition_type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2288">The type of animation used for transitions between modes and children.
+
+The transition type can be changed without problems at runtime, so it is
+possible to change the animation based on the mode or child that is about
+to become current.</doc>
+        <type name="LeafletTransitionType"/>
+      </property>
+      <property name="visible-child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_child"
+                getter="get_visible_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_visible_child"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_visible_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2253">The widget currently visible when the leaflet is folded.
+
+The transition is determined by [property@Adw.Leaflet:transition-type] and
+[Adw.Leaflet:child-transition-duration]. The transition can be cancelled by
+the user, in which case visible child will change back to the previously
+visible child.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="visible-child-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_child_name"
+                getter="get_visible_child_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_get_visible_child_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_set_visible_child_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2272">The name of the widget currently visible when the leaflet is folded.
+
+See [property@Adw.Leaflet:visible-child].</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="LeafletClass"
+            c:type="AdwLeafletClass"
+            glib:is-gtype-struct-for="Leaflet">
+      <source-position filename="../src/adw-leaflet.h" line="45"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="LeafletPage"
+           c:symbol-prefix="leaflet_page"
+           c:type="AdwLeafletPage"
+           parent="GObject.Object"
+           glib:type-name="AdwLeafletPage"
+           glib:get-type="adw_leaflet_page_get_type"
+           glib:type-struct="LeafletPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-leaflet.c"
+           line="50">An auxiliary class used by [class@Adw.Leaflet].</doc>
+      <source-position filename="../src/adw-leaflet.h" line="25"/>
+      <method name="get_child"
+              c:identifier="adw_leaflet_page_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2634">Gets the leaflet child th which @self belongs.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="28"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2640">the child to which @self belongs</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2636">a `AdwLeafletPage`</doc>
+            <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="adw_leaflet_page_get_name"
+              glib:get-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2652">Gets the name of @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="31"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2658">the name of @self.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2654">a `AdwLeafletPage`</doc>
+            <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_navigatable"
+              c:identifier="adw_leaflet_page_get_navigatable"
+              glib:get-property="navigatable"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="navigatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2719">Gets whether the child can be navigated to when folded.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-leaflet.c"
+               line="2725">whether @self can be navigated to when folded</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2721">a `AdwLeafletPage`</doc>
+            <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_name"
+              c:identifier="adw_leaflet_page_set_name"
+              glib:set-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2670">Sets the name of the @self.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2672">a `AdwLeafletPage`</doc>
+            <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+          </instance-parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2673">the new value to set</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_navigatable"
+              c:identifier="adw_leaflet_page_set_navigatable"
+              glib:set-property="navigatable"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="navigatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="2737">Sets whether @self can be navigated to when folded.</doc>
+        <source-position filename="../src/adw-leaflet.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2739">a `AdwLeafletPage`</doc>
+            <type name="LeafletPage" c:type="AdwLeafletPage*"/>
+          </instance-parameter>
+          <parameter name="navigatable" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-leaflet.c"
+                 line="2740">whether @self can be navigated to when folded</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_page_get_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="274">The child of the page.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_name"
+                getter="get_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_page_get_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_page_set_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="288">The name of the child page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="navigatable"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_navigatable"
+                getter="get_navigatable">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_leaflet_page_get_navigatable"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_leaflet_page_set_navigatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="302">Whether the child can be navigated to when folded.
+
+If `FALSE`, the child will be ignored by
+[method@Adw.Leaflet.get_adjacent_child], [method@Adw.Leaflet.navigate], and
+swipe gestures.
+
+This can be used used to prevent switching to widgets like separators.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="LeafletPageClass"
+            c:type="AdwLeafletPageClass"
+            glib:is-gtype-struct-for="LeafletPage">
+      <source-position filename="../src/adw-leaflet.h" line="25"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <enumeration name="LeafletTransitionType"
+                 version="1.0"
+                 glib:type-name="AdwLeafletTransitionType"
+                 glib:get-type="adw_leaflet_transition_type_get_type"
+                 c:type="AdwLeafletTransitionType">
+      <doc xml:space="preserve"
+           filename="../src/adw-leaflet.c"
+           line="56">Describes the possible transitions in a [class@Adw.Leaflet] widget.
+
+New values may be added to this enumeration over time.</doc>
+      <member name="over"
+              value="0"
+              c:identifier="ADW_LEAFLET_TRANSITION_TYPE_OVER"
+              glib:nick="over"
+              glib:name="ADW_LEAFLET_TRANSITION_TYPE_OVER">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="58">Cover the old page or uncover the new page, sliding from or towards the end according to orientation, text direction and children order</doc>
+      </member>
+      <member name="under"
+              value="1"
+              c:identifier="ADW_LEAFLET_TRANSITION_TYPE_UNDER"
+              glib:nick="under"
+              glib:name="ADW_LEAFLET_TRANSITION_TYPE_UNDER">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="59">Uncover the new page or cover the old page, sliding from or towards the start according to orientation, text direction and children order</doc>
+      </member>
+      <member name="slide"
+              value="2"
+              c:identifier="ADW_LEAFLET_TRANSITION_TYPE_SLIDE"
+              glib:nick="slide"
+              glib:name="ADW_LEAFLET_TRANSITION_TYPE_SLIDE">
+        <doc xml:space="preserve"
+             filename="../src/adw-leaflet.c"
+             line="60">Slide from left, right, up or down according to the orientation, text direction and the children order</doc>
+      </member>
+    </enumeration>
+    <constant name="MAJOR_VERSION" value="1" c:type="ADW_MAJOR_VERSION">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.h"
+           line="17">Adw major version component (e.g. 1 if %ADW_VERSION is 1.2.3)</doc>
+      <source-position filename="../src/adw-version.h" line="22"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MICRO_VERSION" value="0" c:type="ADW_MICRO_VERSION">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.h"
+           line="31">Adw micro version component (e.g. 3 if %ADW_VERSION is 1.2.3)</doc>
+      <source-position filename="../src/adw-version.h" line="36"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <constant name="MINOR_VERSION" value="0" c:type="ADW_MINOR_VERSION">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.h"
+           line="24">Adw minor version component (e.g. 2 if %ADW_VERSION is 1.2.3)</doc>
+      <source-position filename="../src/adw-version.h" line="29"/>
+      <type name="gint" c:type="gint"/>
+    </constant>
+    <enumeration name="NavigationDirection"
+                 version="1.0"
+                 glib:type-name="AdwNavigationDirection"
+                 glib:get-type="adw_navigation_direction_get_type"
+                 c:type="AdwNavigationDirection">
+      <doc xml:space="preserve"
+           filename="../src/adw-navigation-direction.c"
+           line="10">Describes the direction of a swipe navigation gesture.</doc>
+      <member name="back"
+              value="0"
+              c:identifier="ADW_NAVIGATION_DIRECTION_BACK"
+              glib:nick="back"
+              glib:name="ADW_NAVIGATION_DIRECTION_BACK">
+        <doc xml:space="preserve"
+             filename="../src/adw-navigation-direction.c"
+             line="12">Corresponds to start or top, depending on orientation and text direction</doc>
+      </member>
+      <member name="forward"
+              value="1"
+              c:identifier="ADW_NAVIGATION_DIRECTION_FORWARD"
+              glib:nick="forward"
+              glib:name="ADW_NAVIGATION_DIRECTION_FORWARD">
+        <doc xml:space="preserve"
+             filename="../src/adw-navigation-direction.c"
+             line="13">Corresponds to end or bottom, depending on orientation and text direction</doc>
+      </member>
+    </enumeration>
+    <class name="PreferencesGroup"
+           c:symbol-prefix="preferences_group"
+           c:type="AdwPreferencesGroup"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwPreferencesGroup"
+           glib:get-type="adw_preferences_group_get_type"
+           glib:type-struct="PreferencesGroupClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-preferences-group.c"
+           line="15">A group of preference rows.
+
+An `AdwPreferencesGroup` represents a group or tightly related preferences,
+which in turn are represented by [class@Adw.PreferencesRow].
+
+To summarize the role of the preferences it gathers, a group can have both a
+title and a description. The title will be used by
+[class@Adw.PreferencesWindow] to let the user look for a preference.
+
+## CSS nodes
+
+`AdwPreferencesGroup` has a single CSS node with name `preferencesgroup`.</doc>
+      <source-position filename="../src/adw-preferences-group.h" line="34"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_preferences_group_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="259">Creates a new `AdwPreferencesGroup`.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-group.c"
+               line="264">the newly created `AdwPreferencesGroup`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add"
+              c:identifier="adw_preferences_group_add"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="420">Adds a child to @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="52"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="422">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="423">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_description"
+              c:identifier="adw_preferences_group_get_description"
+              glib:get-property="description"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="324">Gets the description of @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="46"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-group.c"
+               line="330">the description of @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="326">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_preferences_group_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="274">Gets the title of @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-group.c"
+               line="280">the title of @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="276">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove"
+              c:identifier="adw_preferences_group_remove"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="446">Removes a child from @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="55"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="448">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="449">the child to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_description"
+              c:identifier="adw_preferences_group_set_description"
+              glib:set-property="description"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="346">Sets the description for @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="348">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+          <parameter name="description"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="349">the description</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_preferences_group_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="296">Sets the title for @self.</doc>
+        <source-position filename="../src/adw-preferences-group.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="298">a `AdwPreferencesGroup`</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-group.c"
+                 line="299">the title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="description"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_description"
+                getter="get_description">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_group_get_description"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_group_set_description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="177">The description for this group of preferences.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_group_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_group_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.c"
+             line="191">The title for this group of preferences.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.Widget" c:type="GtkWidget"/>
+      </field>
+    </class>
+    <record name="PreferencesGroupClass"
+            c:type="AdwPreferencesGroupClass"
+            glib:is-gtype-struct-for="PreferencesGroup">
+      <source-position filename="../src/adw-preferences-group.h" line="34"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-group.h"
+             line="26">The parent class</doc>
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="PreferencesPage"
+           c:symbol-prefix="preferences_page"
+           c:type="AdwPreferencesPage"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwPreferencesPage"
+           glib:get-type="adw_preferences_page_get_type"
+           glib:type-struct="PreferencesPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-preferences-page.c"
+           line="15">A page from [class@Adw.PreferencesWindow].
+
+The `AdwPreferencesPage` widget gathers preferences groups into a single page
+of a preferences window.
+
+## CSS nodes
+
+`AdwPreferencesPage` has a single CSS node with name `preferencespage`.</doc>
+      <source-position filename="../src/adw-preferences-page.h" line="35"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_preferences_page_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="250">Creates a new `AdwPreferencesPage`.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-page.c"
+               line="255">the newly created `AdwPreferencesPage`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add" c:identifier="adw_preferences_page_add" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="501">Adds a preferences group to @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="65"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="503">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="group" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="504">the group to add</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_preferences_page_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="265">Gets the icon name for @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="41"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-page.c"
+               line="271">the icon name for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="267">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="adw_preferences_page_get_name"
+              glib:get-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="365">Gets the name of @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="53"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-page.c"
+               line="371">the name of @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="367">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_preferences_page_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="315">Gets the title of @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="47"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-page.c"
+               line="321">the title of @self.</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="317">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_underline"
+              c:identifier="adw_preferences_page_get_use_underline"
+              glib:get-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="450">Gets whether an embedded underline in the title indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="59"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-page.c"
+               line="456">whether an embedded underline in the title indicates a mnemonic</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="452">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove"
+              c:identifier="adw_preferences_page_remove"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="524">Removes a group from @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="68"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="526">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="group" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="527">the group to remove</doc>
+            <type name="PreferencesGroup" c:type="AdwPreferencesGroup*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_preferences_page_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="287">Sets the icon name for @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="43"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="289">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="290">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_name"
+              c:identifier="adw_preferences_page_set_name"
+              glib:set-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="387">Sets the name of @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="55"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="389">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="390">the name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_preferences_page_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="337">Sets the title of @self.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="49"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="339">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="340">the title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_underline"
+              c:identifier="adw_preferences_page_set_use_underline"
+              glib:set-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="472">Sets whether an embedded underline in the title indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-preferences-page.h" line="61"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="474">a `AdwPreferencesPage`</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </instance-parameter>
+          <parameter name="use_underline" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-page.c"
+                 line="475">`TRUE` if underlines in the text indicate mnemonics</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_page_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_page_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="152">The icon name for this page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_name"
+                getter="get_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_page_get_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_page_set_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="180">The name of this page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_page_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_page_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="166">The title for this page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="use-underline"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_underline"
+                getter="get_use_underline">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_page_get_use_underline"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_page_set_use_underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.c"
+             line="194">Whether an embedded underline in the title indicates a mnemonic.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.Widget" c:type="GtkWidget"/>
+      </field>
+    </class>
+    <record name="PreferencesPageClass"
+            c:type="AdwPreferencesPageClass"
+            glib:is-gtype-struct-for="PreferencesPage">
+      <source-position filename="../src/adw-preferences-page.h" line="35"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-page.h"
+             line="27">The parent class</doc>
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="PreferencesRow"
+           c:symbol-prefix="preferences_row"
+           c:type="AdwPreferencesRow"
+           version="1.0"
+           parent="Gtk.ListBoxRow"
+           glib:type-name="AdwPreferencesRow"
+           glib:get-type="adw_preferences_row_get_type"
+           glib:type-struct="PreferencesRowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-preferences-row.c"
+           line="11">A [class@Gtk.ListBoxRow] used to present preferences.
+
+The `AdwPreferencesRow` widget has a title that [class@Adw.PreferencesWindow]
+will use to let the user look for a preference. It doesn't present the title
+in any way and lets you present the preference as you please.
+
+[class@Adw.ActionRow] and its derivatives are convenient to use as preference
+rows as they take care of presenting the preference's title while letting you
+compose the inputs of the preference around it.</doc>
+      <source-position filename="../src/adw-preferences-row.h" line="34"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_preferences_row_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="143">Creates a new `AdwPreferencesRow`.</doc>
+        <source-position filename="../src/adw-preferences-row.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-row.c"
+               line="148">the newly created `AdwPreferencesRow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_title"
+              c:identifier="adw_preferences_row_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="158">Gets the title of the preference represented by @self.</doc>
+        <source-position filename="../src/adw-preferences-row.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-row.c"
+               line="164">the title</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="160">a `AdwPreferencesRow`</doc>
+            <type name="PreferencesRow" c:type="AdwPreferencesRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_underline"
+              c:identifier="adw_preferences_row_get_use_underline"
+              glib:get-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="208">Gets whether an embedded underline in the title indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-preferences-row.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-row.c"
+               line="214">whether an embedded underline in the title indicates a mnemonic</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="210">a `AdwPreferencesRow`</doc>
+            <type name="PreferencesRow" c:type="AdwPreferencesRow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_preferences_row_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="180">Sets the title of the preference represented by @self.</doc>
+        <source-position filename="../src/adw-preferences-row.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="182">a `AdwPreferencesRow`</doc>
+            <type name="PreferencesRow" c:type="AdwPreferencesRow*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="183">the title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_underline"
+              c:identifier="adw_preferences_row_set_use_underline"
+              glib:set-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="230">Sets whether an embedded underline in the title indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-preferences-row.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="232">a `AdwPreferencesRow`</doc>
+            <type name="PreferencesRow" c:type="AdwPreferencesRow*"/>
+          </instance-parameter>
+          <parameter name="use_underline" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-row.c"
+                 line="233">`TRUE` if underlines in the text indicate mnemonics</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_row_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_row_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="105">The title of the preference represented by this row.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="use-underline"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_underline"
+                getter="get_use_underline">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_row_get_use_underline"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_row_set_use_underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.c"
+             line="119">Whether an embedded underline in the title indicates a mnemonic.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.ListBoxRow" c:type="GtkListBoxRow"/>
+      </field>
+    </class>
+    <record name="PreferencesRowClass"
+            c:type="AdwPreferencesRowClass"
+            glib:is-gtype-struct-for="PreferencesRow">
+      <source-position filename="../src/adw-preferences-row.h" line="34"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-row.h"
+             line="26">The parent class</doc>
+        <type name="Gtk.ListBoxRowClass" c:type="GtkListBoxRowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="PreferencesWindow"
+           c:symbol-prefix="preferences_window"
+           c:type="AdwPreferencesWindow"
+           version="1.0"
+           parent="Window"
+           glib:type-name="AdwPreferencesWindow"
+           glib:get-type="adw_preferences_window_get_type"
+           glib:type-struct="PreferencesWindowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-preferences-window.c"
+           line="22">A window to present an application's preferences.
+
+The `AdwPreferencesWindow` widget presents an application's preferences
+gathered into pages and groups. The preferences are searchable by the user.
+
+## CSS nodes
+
+`AdwPreferencesWindow` has a main CSS node with the name `window` and the
+style class `.preferences`.</doc>
+      <source-position filename="../src/adw-preferences-window.h" line="36"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Native"/>
+      <implements name="Gtk.Root"/>
+      <implements name="Gtk.ShortcutManager"/>
+      <constructor name="new"
+                   c:identifier="adw_preferences_window_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="662">Creates a new `AdwPreferencesWindow`.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-window.c"
+               line="667">the newly created `AdwPreferencesWindow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add"
+              c:identifier="adw_preferences_window_add"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="850">Adds a preferences page to @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="852">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="853">the page to add</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_subpage"
+              c:identifier="adw_preferences_window_close_subpage"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="823">Closes the current subpage.
+
+If there is no presented subpage, this does nothing.
+
+See [method@Adw.PreferencesWindow.close_subpage].</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="825">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_can_swipe_back"
+              c:identifier="adw_preferences_window_get_can_swipe_back"
+              glib:get-property="can-swipe-back"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="can-swipe-back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="764">Gets whether or not @self allows closing subpages via a swipe gesture.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-window.c"
+               line="770">whether back swipe is enabled.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="766">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_search_enabled"
+              c:identifier="adw_preferences_window_get_search_enabled"
+              glib:get-property="search-enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="search-enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="677">Gets whether search is enabled for @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-window.c"
+               line="683">whether search is enabled for @self.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="679">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_page"
+              c:identifier="adw_preferences_window_get_visible_page"
+              glib:get-property="visible-page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="905">Gets the currently visible page of @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="67"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-window.c"
+               line="911">the visible page</doc>
+          <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="907">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_page_name"
+              c:identifier="adw_preferences_window_get_visible_page_name"
+              glib:get-property="visible-page-name"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="950">Gets the name of currently visible page of @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="73"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-preferences-window.c"
+               line="956">the name of the visible page</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="952">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="present_subpage"
+              c:identifier="adw_preferences_window_present_subpage"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="786">Sets @subpage as the window's subpage and opens it.
+
+The transition can be cancelled by the user, in which case visible child will
+change back to the previously visible child.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="788">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="subpage" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="789">the subpage</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="remove"
+              c:identifier="adw_preferences_window_remove"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="879">Removes a page from @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="63"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="881">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="882">the page to remove</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_can_swipe_back"
+              c:identifier="adw_preferences_window_set_can_swipe_back"
+              glib:set-property="can-swipe-back"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="can-swipe-back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="735">Sets whether or not @self allows closing subpages via a swipe gesture.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="737">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="can_swipe_back" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="738">the new value</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_search_enabled"
+              c:identifier="adw_preferences_window_set_search_enabled"
+              glib:set-property="search-enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="search-enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="699">Sets whether search is enabled for @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="701">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="search_enabled" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="702">whether search is enabled</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_page"
+              c:identifier="adw_preferences_window_set_visible_page"
+              glib:set-property="visible-page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="927">Makes @page the visible page of @self.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="69"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="929">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="930">a page of @self</doc>
+            <type name="PreferencesPage" c:type="AdwPreferencesPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_page_name"
+              c:identifier="adw_preferences_window_set_visible_page_name"
+              glib:set-property="visible-page-name"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="972">Makes the page with the given name visible.</doc>
+        <source-position filename="../src/adw-preferences-window.h" line="75"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="974">a `AdwPreferencesWindow`</doc>
+            <type name="PreferencesWindow" c:type="AdwPreferencesWindow*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-preferences-window.c"
+                 line="975">the name of the page to make visible</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="can-swipe-back"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_can_swipe_back"
+                getter="get_can_swipe_back">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_window_get_can_swipe_back"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_window_set_can_swipe_back"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="561">Whether or not the window allows closing subpages via a swipe gesture.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="search-enabled"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_search_enabled"
+                getter="get_search_enabled">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_preferences_window_get_search_enabled"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_preferences_window_set_search_enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.c"
+             line="547">Whether search is enabled.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="visible-page"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_page"
+                getter="get_visible_page">
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="visible-page-name"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_page_name"
+                getter="get_visible_page_name">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Window" c:type="AdwWindow"/>
+      </field>
+    </class>
+    <record name="PreferencesWindowClass"
+            c:type="AdwPreferencesWindowClass"
+            glib:is-gtype-struct-for="PreferencesWindow">
+      <source-position filename="../src/adw-preferences-window.h" line="36"/>
+      <field name="parent_class">
+        <doc xml:space="preserve"
+             filename="../src/adw-preferences-window.h"
+             line="28">The parent class</doc>
+        <type name="WindowClass" c:type="AdwWindowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="SplitButton"
+           c:symbol-prefix="split_button"
+           c:type="AdwSplitButton"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwSplitButton"
+           glib:get-type="adw_split_button_get_type"
+           glib:type-struct="SplitButtonClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-split-button.c"
+           line="13">A combined button and dropdown widget.
+
+`AdwSplitButton` is typically used to present a set of actions in a menu,
+but allow access to one of them with a single click.
+
+The API is very similar to [class@Gtk.Button] and [class@Gtk.MenuButton], see
+their documentation for details.
+
+## CSS nodes
+
+```
+splitbutton[.image-button][.text-button]
+├── button
+│   ╰── &lt;content&gt;
+├── separator
+╰── menubutton
+    ╰── button.toggle
+        ╰── arrow
+```
+
+`AdwSplitButton`'s CSS node is called `splitbutton`. It contains the css
+nodes: `button`, `separator`, `menubutton`. See [class@Gtk.MenuButton]
+documentation for the `menubutton` contents.
+
+The main CSS node will contain the `.image-button` or `.text-button` style
+classes matching the button contents. The nested button nodes will never
+contain them.
+
+## Accessibility
+
+`AdwSplitButton` uses the `GTK_ACCESSIBLE_ROLE_BUTTON` role.</doc>
+      <source-position filename="../src/adw-split-button.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Actionable"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_split_button_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="571">Creates a new `AdwSplitButton`.</doc>
+        <source-position filename="../src/adw-split-button.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="576">the newly created `AdwSplitButton`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_child"
+              c:identifier="adw_split_button_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="731">Gets the child widget.</doc>
+        <source-position filename="../src/adw-split-button.h" line="46"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="737">the child widget</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="733">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_direction"
+              c:identifier="adw_split_button_get_direction"
+              glib:get-property="direction"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="direction"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="859">Gets the direction in which the popup will be popped up.</doc>
+        <source-position filename="../src/adw-split-button.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="865">the direction</doc>
+          <type name="Gtk.ArrowType" c:type="GtkArrowType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="861">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_split_button_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="677">Gets the name of the icon used to automatically populate the button.
+
+If the icon name has not been set with [method@Adw.SplitButton.set_icon_name]
+the return value will be `NULL`.</doc>
+        <source-position filename="../src/adw-split-button.h" line="40"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="686">the icon name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="679">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_label"
+              c:identifier="adw_split_button_get_label"
+              glib:get-property="label"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="586">Gets the label for @self.</doc>
+        <source-position filename="../src/adw-split-button.h" line="28"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="592">the label for @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="588">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_menu_model"
+              c:identifier="adw_split_button_get_menu_model"
+              glib:get-property="menu-model"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="menu-model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="781">Gets the menu model from which the popup will be created.</doc>
+        <source-position filename="../src/adw-split-button.h" line="52"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="787">the menu model</doc>
+          <type name="Gio.MenuModel" c:type="GMenuModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="783">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_popover"
+              c:identifier="adw_split_button_get_popover"
+              glib:get-property="popover"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="popover"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="820">Gets the popover that will be popped up when the dropdown is clicked.</doc>
+        <source-position filename="../src/adw-split-button.h" line="58"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="826">the popover</doc>
+          <type name="Gtk.Popover" c:type="GtkPopover*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="822">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_underline"
+              c:identifier="adw_split_button_get_use_underline"
+              glib:get-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="636">Gets whether an underline in the text indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-split-button.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-split-button.c"
+               line="642">whether an underline in the text indicates a mnemonic</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="638">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="popdown"
+              c:identifier="adw_split_button_popdown"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="916">Dismisses the menu.</doc>
+        <source-position filename="../src/adw-split-button.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="918">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="popup" c:identifier="adw_split_button_popup" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="900">Pops up the menu.</doc>
+        <source-position filename="../src/adw-split-button.h" line="70"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="902">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_child"
+              c:identifier="adw_split_button_set_child"
+              glib:set-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="749">Sets the child widget.</doc>
+        <source-position filename="../src/adw-split-button.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="751">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="child"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="752">the new child widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_direction"
+              c:identifier="adw_split_button_set_direction"
+              glib:set-property="direction"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="direction"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="877">Sets the direction in which the popup will be popped up.</doc>
+        <source-position filename="../src/adw-split-button.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="879">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="880">the direction</doc>
+            <type name="Gtk.ArrowType" c:type="GtkArrowType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_split_button_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="698">Sets the name of the icon used to automatically populate the button.</doc>
+        <source-position filename="../src/adw-split-button.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="700">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="icon_name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="701">the icon name to set</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_label"
+              c:identifier="adw_split_button_set_label"
+              glib:set-property="label"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="604">Sets the label for @self.</doc>
+        <source-position filename="../src/adw-split-button.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="606">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="label" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="607">the label to set</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_menu_model"
+              c:identifier="adw_split_button_set_menu_model"
+              glib:set-property="menu-model"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="menu-model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="799">Sets the menu model from which the popup will be created.</doc>
+        <source-position filename="../src/adw-split-button.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="801">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="menu_model"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="802">the menu model</doc>
+            <type name="Gio.MenuModel" c:type="GMenuModel*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_popover"
+              c:identifier="adw_split_button_set_popover"
+              glib:set-property="popover"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="popover"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="838">Sets the popover that will be popped up when the dropdown is clicked.</doc>
+        <source-position filename="../src/adw-split-button.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="840">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="popover"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="841">the popover</doc>
+            <type name="Gtk.Popover" c:type="GtkPopover*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_underline"
+              c:identifier="adw_split_button_set_use_underline"
+              glib:set-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="654">Sets whether an underline in the text indicates a mnemonic.</doc>
+        <source-position filename="../src/adw-split-button.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="656">a `AdwSplitButton`</doc>
+            <type name="SplitButton" c:type="AdwSplitButton*"/>
+          </instance-parameter>
+          <parameter name="use_underline" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-split-button.c"
+                 line="657">whether an underline in the text indicates a mnemonic</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_child"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="314">The child widget.
+
+Setting the child widget will set [property@Adw.SplitButton:label] and
+[property@Adw.SplitButton:icon-name] to `NULL`.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="direction"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_direction"
+                getter="get_direction">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_direction"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_direction"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="373">The direction in which the popup will be popped up.
+
+The dropdown arrow icon will point at the same direction.
+
+If the does not fit in the available space in the given direction,
+GTK will its best to keep it inside the screen and fully visible.
+
+If you pass `GTK_ARROW_NONE`, it's equivalent to `GTK_ARROW_DOWN`.</doc>
+        <type name="Gtk.ArrowType"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="297">The name of the icon used to automatically populate the button.
+
+Setting the icon name will set [property@Adw.SplitButton:label] and
+[property@Adw.SplitButton:child] to `NULL`.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="label"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_label"
+                getter="get_label">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_label"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_label"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="264">The label for the button.
+
+Setting the label will set [property@Adw.SplitButton:icon-name] and
+[property@Adw.SplitButton:child] to `NULL`.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="menu-model"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_menu_model"
+                getter="get_menu_model">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_menu_model"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_menu_model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="331">The `GMenuModel` from which the popup will be created.
+
+If the menu model is `NULL`, the dropdown is disabled.
+
+A [class@Gtk.Popover] will be created from the menu model with
+[ctor@Gtk.PopoverMenu.new_from_model]. Actions will be connected
+as documented for this function.
+
+If [property@Adw.SplitButton:popover] is already set, it will be
+dissociated from the button, and the property is set to `NULL`.</doc>
+        <type name="Gio.MenuModel"/>
+      </property>
+      <property name="popover"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_popover"
+                getter="get_popover">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_popover"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_popover"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="354">The `GtkPopover` that will be popped up when the dropdown is clicked.
+
+If the popover is `NULL`, the dropdown is disabled.
+
+If [property@Adw.SplitButton:menu-model] is set, the menu model is
+dissociated from the button, and the property is set to `NULL`.</doc>
+        <type name="Gtk.Popover"/>
+      </property>
+      <property name="use-underline"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_underline"
+                getter="get_use_underline">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_split_button_get_use_underline"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_split_button_set_use_underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="281">Whether an underline in the text indicates a mnemonic.
+
+See [property@Adw.SplitButton:label].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <glib:signal name="activate" when="first" action="1" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="415">Emitted to animate press then release.
+
+This is an action signal. Applications should never connect
+to this signal, but use the [signal@Adw.SplitButton::clicked] signal.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="clicked" when="first" action="1" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-split-button.c"
+             line="400">Emitted when the button has been activated (pressed and released).</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+      </glib:signal>
+    </class>
+    <record name="SplitButtonClass"
+            c:type="AdwSplitButtonClass"
+            glib:is-gtype-struct-for="SplitButton">
+      <source-position filename="../src/adw-split-button.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="Squeezer"
+           c:symbol-prefix="squeezer"
+           c:type="AdwSqueezer"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwSqueezer"
+           glib:get-type="adw_squeezer_get_type"
+           glib:type-struct="SqueezerClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-squeezer.c"
+           line="26">A best fit container.
+
+The `AdwSqueezer` widget is a container which only shows the first of its
+children that fits in the available size. It is convenient to offer different
+widgets to represent the same data with different levels of detail, making
+the widget seem to squeeze itself to fit in the available space.
+
+Transitions between children can be animated as fades. This can be controlled
+with [property@Adw.Squeezer:transition-type].
+
+## CSS nodes
+
+`AdwSqueezer` has a single CSS node with name `squeezer`.</doc>
+      <source-position filename="../src/adw-squeezer.h" line="38"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new" c:identifier="adw_squeezer_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1397">Creates a new `AdwSqueezer`.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1402">the newly created `AdwSqueezer`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add" c:identifier="adw_squeezer_add" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1412">Adds a child to @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="49"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1419">the [class@Adw.SqueezerPage] for @child</doc>
+          <type name="SqueezerPage" c:type="AdwSqueezerPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1414">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1415">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_allow_none"
+              c:identifier="adw_squeezer_get_allow_none"
+              glib:get-property="allow-none"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="allow-none"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1585">Gets whether to allow squeezing beyond the last child's minimum size.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="72"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1591">whether @self allows squeezing beyond the last child</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1587">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_homogeneous"
+              c:identifier="adw_squeezer_get_homogeneous"
+              glib:get-property="homogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1496">Gets whether all children have the same size for the opposite orientation.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1502">whether @self is homogeneous</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1498">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_interpolate_size"
+              c:identifier="adw_squeezer_get_interpolate_size"
+              glib:get-property="interpolate-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="interpolate-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1728">Gets whether @self interpolates its size when changing the visible child.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="93"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1734">whether the size is interpolated</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1730">A `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_page"
+              c:identifier="adw_squeezer_get_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1475">Returns the [class@Adw.SqueezerPage] object for @child.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1482">the page object for @child</doc>
+          <type name="SqueezerPage" c:type="AdwSqueezerPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1477">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1478">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_pages"
+              c:identifier="adw_squeezer_get_pages"
+              glib:get-property="pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1874">Returns a [iface@Gio.ListModel] that contains the pages of @self.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track the visible page.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="114"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1883">a `GtkSelectionModel` for the squeezer's children</doc>
+          <type name="Gtk.SelectionModel" c:type="GtkSelectionModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1876">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_switch_threshold_policy"
+              c:identifier="adw_squeezer_get_switch_threshold_policy"
+              glib:get-property="switch-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="switch-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1542">Gets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1544">a `AdwLeaflet`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_duration"
+              c:identifier="adw_squeezer_get_transition_duration"
+              glib:get-property="transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1630">Gets the transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="78"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1636">the transition duration, in milliseconds</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1632">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_running"
+              c:identifier="adw_squeezer_get_transition_running"
+              glib:get-property="transition-running"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="transition-running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1710">Gets whether a transition is currently running for @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="90"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1716">whether a transition is currently running</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1712">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_type"
+              c:identifier="adw_squeezer_get_transition_type"
+              glib:get-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1670">Gets the type of animation used for transitions between children in @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="84"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1676">the current transition type of @self</doc>
+          <type name="SqueezerTransitionType"
+                c:type="AdwSqueezerTransitionType"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1672">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_child"
+              c:identifier="adw_squeezer_get_visible_child"
+              glib:get-property="visible-child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="visible-child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1770">Gets the currently visible child of @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="99"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1776">the visible child</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1772">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_xalign"
+              c:identifier="adw_squeezer_get_xalign"
+              glib:get-property="xalign"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="xalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1788">Gets the horizontal alignment, from 0 (start) to 1 (end).</doc>
+        <source-position filename="../src/adw-squeezer.h" line="102"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1794">the alignment value</doc>
+          <type name="gfloat" c:type="float"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1790">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_yalign"
+              c:identifier="adw_squeezer_get_yalign"
+              glib:get-property="yalign"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="yalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1831">Gets the vertical alignment, from 0 (top) to 1 (bottom).</doc>
+        <source-position filename="../src/adw-squeezer.h" line="108"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1837">the alignment value</doc>
+          <type name="gfloat" c:type="float"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1833">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_squeezer_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1442">Removes a child widget from @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="52"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1444">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1445">the child to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_none"
+              c:identifier="adw_squeezer_set_allow_none"
+              glib:set-property="allow-none"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="allow-none"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1603">Sets whether to allow squeezing beyond the last child's minimum size.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="74"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1605">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="allow_none" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1606">whether @self allows squeezing beyond the last child</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_homogeneous"
+              c:identifier="adw_squeezer_set_homogeneous"
+              glib:set-property="homogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1514">Sets whether all children have the same size for the opposite orientation.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="62"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1516">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="homogeneous" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1517">whether @self is homogeneous</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_interpolate_size"
+              c:identifier="adw_squeezer_set_interpolate_size"
+              glib:set-property="interpolate-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="interpolate-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1746">Sets whether @self interpolates its size when changing the visible child.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="95"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1748">A `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="interpolate_size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1749">whether to interpolate the size</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_switch_threshold_policy"
+              c:identifier="adw_squeezer_set_switch_threshold_policy"
+              glib:set-property="switch-threshold-policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="switch-threshold-policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1559">Sets the fold threshold policy for @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="68"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1561">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1562">the policy to use</doc>
+            <type name="FoldThresholdPolicy" c:type="AdwFoldThresholdPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_transition_duration"
+              c:identifier="adw_squeezer_set_transition_duration"
+              glib:set-property="transition-duration"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="transition-duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1648">Sets the transition animation duration for @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="80"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1650">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1651">the new duration, in milliseconds</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_transition_type"
+              c:identifier="adw_squeezer_set_transition_type"
+              glib:set-property="transition-type"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="transition-type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1688">Sets the type of animation used for transitions between children in @self.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="86"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1690">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="transition" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1691">the new transition type</doc>
+            <type name="SqueezerTransitionType"
+                  c:type="AdwSqueezerTransitionType"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_xalign"
+              c:identifier="adw_squeezer_set_xalign"
+              glib:set-property="xalign"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="xalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1806">Sets the horizontal alignment, from 0 (start) to 1 (end).</doc>
+        <source-position filename="../src/adw-squeezer.h" line="104"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1808">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="xalign" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1809">the new alignment value</doc>
+            <type name="gfloat" c:type="float"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_yalign"
+              c:identifier="adw_squeezer_set_yalign"
+              glib:set-property="yalign"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="yalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1849">Sets the vertical alignment, from 0 (top) to 1 (bottom).</doc>
+        <source-position filename="../src/adw-squeezer.h" line="110"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1851">a `AdwSqueezer`</doc>
+            <type name="Squeezer" c:type="AdwSqueezer*"/>
+          </instance-parameter>
+          <parameter name="yalign" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1852">the new alignment value</doc>
+            <type name="gfloat" c:type="float"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="allow-none"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_none"
+                getter="get_allow_none">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_allow_none"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_allow_none"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1153">Whether to allow squeezing beyond the last child's minimum size.
+
+If set to `TRUE`, the squeezer can shrink to the point where no child can
+be shown. This is functionally equivalent to appending a widget with 0x0
+minimum size.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="homogeneous"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_homogeneous"
+                getter="get_homogeneous">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_homogeneous"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_homogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1098">Whether all children have the same size for the opposite orientation.
+
+For example, if a squeezer is horizontal and is homogeneous, it will request
+the same height for all its children. If it isn't, the squeezer may change
+size when a different child becomes visible.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="interpolate-size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_interpolate_size"
+                getter="get_interpolate_size">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_interpolate_size"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_interpolate_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1214">Whether the squeezer interpolates its size when changing the visible child.
+
+If `TRUE`, the squeezer will interpolate its size between the one of the
+previous visible child and the one of the new visible child, according to
+the set transition duration and the orientation, e.g. if the squeezer is
+horizontal, it will interpolate the its height.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_pages">
+        <attribute name="org.gtk.Property.get" value="adw_squeezer_get_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1275">A selection model with the squeezer's pages.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track the visible page.</doc>
+        <type name="Gtk.SelectionModel"/>
+      </property>
+      <property name="switch-threshold-policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_switch_threshold_policy"
+                getter="get_switch_threshold_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_switch_threshold_policy"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_switch_threshold_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1116">Determines when the squeezer will switch children.
+
+If set to `ADW_FOLD_THRESHOLD_POLICY_MINIMUM`, it will only switch when
+the visible child cannot fit anymore. With
+`ADW_FOLD_THRESHOLD_POLICY_NATURAL`, it will switch as soon as the visible
+child doesn't get their natural size.
+
+This can be useful if you have a long ellipsizing label and want to let it
+ellipsize instead of immediately switching.</doc>
+        <type name="FoldThresholdPolicy"/>
+      </property>
+      <property name="transition-duration"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_transition_duration"
+                getter="get_transition_duration">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_transition_duration"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_transition_duration"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1171">The animation duration, in milliseconds.</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="transition-running"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_transition_running">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_transition_running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1200">Whether a transition is currently running.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="transition-type"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_transition_type"
+                getter="get_transition_type">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_transition_type"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_transition_type"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1185">The type of animation used for transitions between children.</doc>
+        <type name="SqueezerTransitionType"/>
+      </property>
+      <property name="visible-child"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_visible_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_visible_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1139">The currently visible child.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="xalign"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_xalign"
+                getter="get_xalign">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_xalign"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_xalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1233">The horizontal alignment, from 0 (start) to 1 (end).
+
+This affects the children allocation during transitions, when they exceed
+the size of the squeezer.
+
+For example, 0.5 means the child will be centered, 0 means it will keep the
+start side aligned and overflow the end side, and 1 means the opposite.</doc>
+        <type name="gfloat" c:type="gfloat"/>
+      </property>
+      <property name="yalign"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_yalign"
+                getter="get_yalign">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_get_yalign"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_squeezer_set_yalign"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1254">The vertical alignment, from 0 (top) to 1 (bottom).
+
+This affects the children allocation during transitions, when they exceed
+the size of the squeezer.
+
+For example, 0.5 means the child will be centered, 0 means it will keep the
+top side aligned and overflow the bottom side, and 1 means the opposite.</doc>
+        <type name="gfloat" c:type="gfloat"/>
+      </property>
+    </class>
+    <record name="SqueezerClass"
+            c:type="AdwSqueezerClass"
+            glib:is-gtype-struct-for="Squeezer">
+      <source-position filename="../src/adw-squeezer.h" line="38"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="SqueezerPage"
+           c:symbol-prefix="squeezer_page"
+           c:type="AdwSqueezerPage"
+           parent="GObject.Object"
+           glib:type-name="AdwSqueezerPage"
+           glib:get-type="adw_squeezer_page_get_type"
+           glib:type-struct="SqueezerPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-squeezer.c"
+           line="46">An auxiliary class used by [class@Adw.Squeezer].</doc>
+      <source-position filename="../src/adw-squeezer.h" line="24"/>
+      <method name="get_child"
+              c:identifier="adw_squeezer_page_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1329">Returns the squeezer child to which @self belongs.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="27"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1335">the child to which @self belongs</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1331">a `AdwSqueezerPage`</doc>
+            <type name="SqueezerPage" c:type="AdwSqueezerPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_enabled"
+              c:identifier="adw_squeezer_page_get_enabled"
+              glib:get-property="enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1347">Gets whether @self is enabled.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-squeezer.c"
+               line="1353">whether @self is enabled</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1349">a `AdwSqueezerPage`</doc>
+            <type name="SqueezerPage" c:type="AdwSqueezerPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_enabled"
+              c:identifier="adw_squeezer_page_set_enabled"
+              glib:set-property="enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="1365">Sets whether @self is enabled.</doc>
+        <source-position filename="../src/adw-squeezer.h" line="32"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1367">a `AdwSqueezerPage`</doc>
+            <type name="SqueezerPage" c:type="AdwSqueezerPage*"/>
+          </instance-parameter>
+          <parameter name="enabled" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-squeezer.c"
+                 line="1368">whether @self is enabled</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_page_get_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="212">The child of the page.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="enabled"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_enabled"
+                getter="get_enabled">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_squeezer_page_set_enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="226">Whether the child is enabled.
+
+If a child is disabled, it will be ignored when looking for the child
+fitting the available size best.
+
+This allows to programmatically and prematurely hide a child even if it
+fits in the available space.
+
+This can be used e.g. to ensure a certain child is hidden below a certain
+window width, or any other constraint you find suitable.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="SqueezerPageClass"
+            c:type="AdwSqueezerPageClass"
+            glib:is-gtype-struct-for="SqueezerPage">
+      <source-position filename="../src/adw-squeezer.h" line="24"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <enumeration name="SqueezerTransitionType"
+                 version="1.0"
+                 glib:type-name="AdwSqueezerTransitionType"
+                 glib:get-type="adw_squeezer_transition_type_get_type"
+                 c:type="AdwSqueezerTransitionType">
+      <doc xml:space="preserve"
+           filename="../src/adw-squeezer.c"
+           line="52">Describes the possible transitions in a [class@Adw.Squeezer] widget.</doc>
+      <member name="none"
+              value="0"
+              c:identifier="ADW_SQUEEZER_TRANSITION_TYPE_NONE"
+              glib:nick="none"
+              glib:name="ADW_SQUEEZER_TRANSITION_TYPE_NONE">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="54">No transition</doc>
+      </member>
+      <member name="crossfade"
+              value="1"
+              c:identifier="ADW_SQUEEZER_TRANSITION_TYPE_CROSSFADE"
+              glib:nick="crossfade"
+              glib:name="ADW_SQUEEZER_TRANSITION_TYPE_CROSSFADE">
+        <doc xml:space="preserve"
+             filename="../src/adw-squeezer.c"
+             line="55">A cross-fade</doc>
+      </member>
+    </enumeration>
+    <class name="StatusPage"
+           c:symbol-prefix="status_page"
+           c:type="AdwStatusPage"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwStatusPage"
+           glib:get-type="adw_status_page_get_type"
+           glib:type-struct="StatusPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-status-page.c"
+           line="13">A page used for empty/error states and similar use-cases.
+
+The `AdwStatusPage` widget can have an icon, a title, a description and a
+custom widget which is displayed below them.
+
+## CSS nodes
+
+`AdwStatusPage` has a main CSS node with name `statuspage`.
+
+`AdwStatusPage` can use the `.compact` style class for when it needs to fit
+into a small space such a sidebar or a popover.</doc>
+      <source-position filename="../src/adw-status-page.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_status_page_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="307">Creates a new `AdwStatusPage`.</doc>
+        <source-position filename="../src/adw-status-page.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="312">the newly created `AdwStatusPage`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_child"
+              c:identifier="adw_status_page_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="506">Gets the child widget of @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="52"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="512">the child widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="508">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_description"
+              c:identifier="adw_status_page_get_description"
+              glib:get-property="description"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="465">Gets the description for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="46"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="471">the description</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="467">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_status_page_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="322">Gets the icon name for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="28"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="328">the icon name</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="324">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_paintable"
+              c:identifier="adw_status_page_get_paintable"
+              glib:get-property="paintable"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="paintable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="373">Gets the paintable for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="34"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="379">the paintable</doc>
+          <type name="Gdk.Paintable" c:type="GdkPaintable*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="375">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_status_page_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="424">Gets the title for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-status-page.c"
+               line="430">the title</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="426">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_child"
+              c:identifier="adw_status_page_set_child"
+              glib:set-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="524">Sets the child widget of @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="526">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+          <parameter name="child"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="527">the child widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_description"
+              c:identifier="adw_status_page_set_description"
+              glib:set-property="description"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="483">Sets the description for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="485">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+          <parameter name="description"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="486">the description</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_status_page_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="340">Sets the icon name for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="30"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="342">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="343">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_paintable"
+              c:identifier="adw_status_page_set_paintable"
+              glib:set-property="paintable"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="paintable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="391">Sets the paintable for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="393">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+          <parameter name="paintable"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="394">the paintable</doc>
+            <type name="Gdk.Paintable" c:type="GdkPaintable*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_status_page_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="442">Sets the title for @self.</doc>
+        <source-position filename="../src/adw-status-page.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="444">a `AdwStatusPage`</doc>
+            <type name="StatusPage" c:type="AdwStatusPage*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-status-page.c"
+                 line="445">the title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_child"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_status_page_get_child"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_status_page_set_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="245">The child widget.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="description"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_description"
+                getter="get_description">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_status_page_get_description"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_status_page_set_description"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="231">The description to be displayed below the title.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_status_page_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_status_page_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="185">The name of the icon to be used.
+
+Changing this will clear [property@Adw.StatusPage:paintable] out.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="paintable"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_paintable"
+                getter="get_paintable">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_status_page_get_paintable"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_status_page_set_paintable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="201">The @GdkPaintable to be used.
+
+Changing this will clear [property@Adw.StatusPage:icon-name] out.</doc>
+        <type name="Gdk.Paintable"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_status_page_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_status_page_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-status-page.c"
+             line="217">The title to be displayed below the icon.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="StatusPageClass"
+            c:type="AdwStatusPageClass"
+            glib:is-gtype-struct-for="StatusPage">
+      <source-position filename="../src/adw-status-page.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="StyleManager"
+           c:symbol-prefix="style_manager"
+           c:type="AdwStyleManager"
+           version="1.0"
+           parent="GObject.Object"
+           glib:type-name="AdwStyleManager"
+           glib:get-type="adw_style_manager_get_type"
+           glib:type-struct="StyleManagerClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-style-manager.c"
+           line="35">A class for managing application-wide styling.
+
+`AdwStyleManager` provides a way to query and influence the application
+styles, such as whether to use dark or high contrast appearance.
+
+It allows to set the color scheme via the
+[property@Adw.StyleManager:color-scheme] property, and to query the current
+appearance, as well as whether a system-wide color scheme preference exists.</doc>
+      <source-position filename="../src/adw-style-manager.h" line="33"/>
+      <function name="get_default"
+                c:identifier="adw_style_manager_get_default"
+                version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="524">Gets the default `AdwStyleManager` instance.
+
+It manages all [class@Gdk.Display] instances unless the style manager for
+that display has an override.
+
+See [func@Adw.StyleManager.get_for_display].</doc>
+        <source-position filename="../src/adw-style-manager.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="534">the default style manager</doc>
+          <type name="StyleManager" c:type="AdwStyleManager*"/>
+        </return-value>
+      </function>
+      <function name="get_for_display"
+                c:identifier="adw_style_manager_get_for_display"
+                version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="547">Gets the `AdwStyleManager` instance managing @display.
+
+It can be used to override styles for that specific display instead of the
+whole application.
+
+Most applications should use [func@Adw.StyleManager.get_default] instead.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="558">the style manager for @display</doc>
+          <type name="StyleManager" c:type="AdwStyleManager*"/>
+        </return-value>
+        <parameters>
+          <parameter name="display" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="549">a `GdkDisplay`</doc>
+            <type name="Gdk.Display" c:type="GdkDisplay*"/>
+          </parameter>
+        </parameters>
+      </function>
+      <method name="get_color_scheme"
+              c:identifier="adw_style_manager_get_color_scheme"
+              glib:get-property="color-scheme"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="color-scheme"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="596">Gets the requested application color scheme.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="602">the color scheme</doc>
+          <type name="ColorScheme" c:type="AdwColorScheme"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="598">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_dark"
+              c:identifier="adw_style_manager_get_dark"
+              glib:get-property="dark"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="dark"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="677">Gets whether the application is using dark appearance.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="53"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="683">whether the application is using dark appearance</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="679">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_display"
+              c:identifier="adw_style_manager_get_display"
+              glib:get-property="display"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="display"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="575">Gets the display the style manager is associated with.
+
+The display will be `NULL` for the style manager returned by
+[func@Adw.StyleManager.get_default].</doc>
+        <source-position filename="../src/adw-style-manager.h" line="41"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="584">(nullable): the display</doc>
+          <type name="Gdk.Display" c:type="GdkDisplay*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="577">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_high_contrast"
+              c:identifier="adw_style_manager_get_high_contrast"
+              glib:get-property="high-contrast"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="high-contrast"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="695">Gets whether the application is using high contrast appearance.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="55"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="701">whether the application is using high contrast appearance</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="697">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_system_supports_color_schemes"
+              c:identifier="adw_style_manager_get_system_supports_color_schemes"
+              glib:get-property="system-supports-color-schemes"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="system-supports-color-schemes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="659">Gets whether the system supports color schemes.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-style-manager.c"
+               line="665">whether the system supports color schemes</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="661">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_color_scheme"
+              c:identifier="adw_style_manager_set_color_scheme"
+              glib:set-property="color-scheme"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="color-scheme"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="614">Sets the requested application color scheme.
+
+The effective appearance will be decided based on the application color
+scheme and the system preferred color scheme. The
+[property@Adw.StyleManager:dark] property can be used to query the
+current effective appearance.</doc>
+        <source-position filename="../src/adw-style-manager.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="616">a `AdwStyleManager`</doc>
+            <type name="StyleManager" c:type="AdwStyleManager*"/>
+          </instance-parameter>
+          <parameter name="color_scheme" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-style-manager.c"
+                 line="617">the color scheme</doc>
+            <type name="ColorScheme" c:type="AdwColorScheme"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="color-scheme"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_color_scheme"
+                getter="get_color_scheme">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_style_manager_get_color_scheme"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_style_manager_set_color_scheme"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="390">The requested application color scheme.
+
+The effective appearance will be decided based on the application color
+scheme and the system preferred color scheme. The
+[property@Adw.StyleManager:dark] property can be used to query the
+current effective appearance.
+
+The `ADW_COLOR_SCHEME_PREFER_LIGHT` color scheme results in the application
+using light appearance unless the system prefers dark colors. This is the
+default value.
+
+The `ADW_COLOR_SCHEME_PREFER_DARK` color scheme results in the application
+using dark appearance, but can still switch to the light appearance if the
+system can prefers it, for example, when the high contrast preference is
+enabled.
+
+The `ADW_COLOR_SCHEME_FORCE_LIGHT` and `ADW_COLOR_SCHEME_FORCE_DARK` values
+ignore the system preference entirely. They are useful if the application
+wants to match its UI to its content or to provide a separate color scheme
+switcher.
+
+If a per-[class@Gdk.Display] style manager has its color scheme set to
+`ADW_COLOR_SCHEME_DEFAULT`, it will inherit the color scheme from the
+default style manager.
+
+For the default style manager, `ADW_COLOR_SCHEME_DEFAULT` is equivalent to
+`ADW_COLOR_SCHEME_PREFER_LIGHT`.
+
+The [property@Adw.StyleManager:system-supports-color-schemes] property can
+be used to check if the current environment provides a color scheme
+preference.</doc>
+        <type name="ColorScheme"/>
+      </property>
+      <property name="dark"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_dark">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_style_manager_get_dark"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="455">Whether the application is using dark appearance.
+
+This property can be used to query the current appearance, as requested via
+[property@Adw.StyleManager:color-scheme].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="display"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_display">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_style_manager_get_display"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="373">The display the style manager is associated with.
+
+The display will be `NULL` for the style manager returned by
+[func@Adw.StyleManager.get_default].</doc>
+        <type name="Gdk.Display"/>
+      </property>
+      <property name="high-contrast"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_high_contrast">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_style_manager_get_high_contrast"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="472">Whether the application is using high contrast appearance.
+
+This cannot be overridden by applications.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="system-supports-color-schemes"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_system_supports_color_schemes">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_style_manager_get_system_supports_color_schemes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-style-manager.c"
+             line="435">Whether the system supports color schemes.
+
+This property can be used to check if the current environment provides a
+color scheme preference. For example, applications might want to show a
+separate appearance switcher if it's set to `FALSE`.
+
+See [property@Adw.StyleManager:color-scheme].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="StyleManagerClass"
+            c:type="AdwStyleManagerClass"
+            glib:is-gtype-struct-for="StyleManager">
+      <source-position filename="../src/adw-style-manager.h" line="33"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <class name="SwipeTracker"
+           c:symbol-prefix="swipe_tracker"
+           c:type="AdwSwipeTracker"
+           version="1.0"
+           parent="GObject.Object"
+           glib:type-name="AdwSwipeTracker"
+           glib:get-type="adw_swipe_tracker_get_type"
+           glib:type-struct="SwipeTrackerClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-swipe-tracker.c"
+           line="33">A swipe tracker used in [class@Adw.Carousel] and [class@Adw.Leaflet].
+
+The `AdwSwipeTracker` object can be used for implementing widgets with swipe
+gestures. It supports touch-based swipes, pointer dragging, and touchpad
+scrolling.
+
+The widgets will probably want to expose the
+[property@Adw.SwipeTracker:enabled] property. If they expect to use
+horizontal orientation, [property@Adw.SwipeTracker:reversed] can be used for
+supporting RTL text direction.</doc>
+      <source-position filename="../src/adw-swipe-tracker.h" line="23"/>
+      <implements name="Gtk.Orientable"/>
+      <constructor name="new"
+                   c:identifier="adw_swipe_tracker_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1124">Creates a new `AdwSwipeTracker` for @widget.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="26"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1130">the newly created `AdwSwipeTracker`</doc>
+          <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+        </return-value>
+        <parameters>
+          <parameter name="swipeable" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1126">a widget to add the tracker on</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_allow_long_swipes"
+              c:identifier="adw_swipe_tracker_get_allow_long_swipes"
+              glib:get-property="allow-long-swipes"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="allow-long-swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1297">Gets whether to allow swiping for more than one snap point at a time.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1303">whether long swipes are allowed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1299">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_allow_mouse_drag"
+              c:identifier="adw_swipe_tracker_get_allow_mouse_drag"
+              glib:get-property="allow-mouse-drag"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="allow-mouse-drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1252">Gets whether @self can be dragged with mouse pointer.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1258">whether mouse dragging is allowed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1254">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_enabled"
+              c:identifier="adw_swipe_tracker_get_enabled"
+              glib:get-property="enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1162">Gets whether @self is enabled.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="32"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1168">whether @self is enabled</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1164">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_reversed"
+              c:identifier="adw_swipe_tracker_get_reversed"
+              glib:get-property="reversed"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reversed"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1210">Gets whether @self is reversing the swipe direction.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1216">whether the direction is reversed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1212">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_swipeable"
+              c:identifier="adw_swipe_tracker_get_swipeable"
+              glib:get-property="swipeable"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="swipeable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1144">Get the widget @self is attached to.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="29"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipe-tracker.c"
+               line="1150">the swipeable widget</doc>
+          <type name="Swipeable" c:type="AdwSwipeable*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1146">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_long_swipes"
+              c:identifier="adw_swipe_tracker_set_allow_long_swipes"
+              glib:set-property="allow-long-swipes"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="allow-long-swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1315">Sets whether to allow swiping for more than one snap point at a time.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="52"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1317">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+          <parameter name="allow_long_swipes" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1318">whether to allow long swipes</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_allow_mouse_drag"
+              c:identifier="adw_swipe_tracker_set_allow_mouse_drag"
+              glib:set-property="allow-mouse-drag"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="allow-mouse-drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1270">Sets whether @self can be dragged with mouse pointer.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1272">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+          <parameter name="allow_mouse_drag" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1273">whether to allow mouse dragging</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_enabled"
+              c:identifier="adw_swipe_tracker_set_enabled"
+              glib:set-property="enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1180">Sets whether @self is enabled.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1182">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+          <parameter name="enabled" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1183">whether @self is enabled</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_reversed"
+              c:identifier="adw_swipe_tracker_set_reversed"
+              glib:set-property="reversed"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="reversed"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1228">Sets whether to reverse the swipe direction.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1230">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+          <parameter name="reversed" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1231">whether to reverse the swipe direction</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="shift_position"
+              c:identifier="adw_swipe_tracker_shift_position"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1340">Moves the current progress value by @delta.
+
+This can be used to adjust the current position if snap points move during
+the gesture.</doc>
+        <source-position filename="../src/adw-swipe-tracker.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1342">a `AdwSwipeTracker`</doc>
+            <type name="SwipeTracker" c:type="AdwSwipeTracker*"/>
+          </instance-parameter>
+          <parameter name="delta" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1343">the position delta</doc>
+            <type name="gdouble" c:type="double"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="allow-long-swipes"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_long_swipes"
+                getter="get_allow_long_swipes">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_swipe_tracker_get_allow_long_swipes"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_swipe_tracker_set_allow_long_swipes"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1029">Whether to allow swiping for more than one snap point at a time.
+
+If the value is `FALSE`, each swipe can only move to the adjacent snap
+points.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="allow-mouse-drag"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_allow_mouse_drag"
+                getter="get_allow_mouse_drag">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_swipe_tracker_get_allow_mouse_drag"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_swipe_tracker_set_allow_mouse_drag"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1015">Whether to allow dragging with mouse pointer.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="enabled"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_enabled"
+                getter="get_enabled">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_swipe_tracker_get_enabled"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_swipe_tracker_set_enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="981">Whether the swipe tracker is enabled.
+
+When it's not enabled, no events will be processed. Usually widgets will
+want to expose this via a property.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="reversed"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_reversed"
+                getter="get_reversed">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_swipe_tracker_get_reversed"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_swipe_tracker_set_reversed"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="998">Whether to reverse the swipe direction.
+
+If the swipe tracker is horizontal, it can be used for supporting RTL text
+direction.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="swipeable"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_swipeable">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_swipe_tracker_get_swipeable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="967">The widget the swipe tracker is attached to.</doc>
+        <type name="Swipeable"/>
+      </property>
+      <glib:signal name="begin-swipe" when="first" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1052">This signal is emitted when a possible swipe is detected.
+
+The @direction value can be used to restrict the swipe to a certain
+direction.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1055">the direction of the swipe</doc>
+            <type name="NavigationDirection"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="end-swipe" when="first" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1093">This signal is emitted as soon as the gesture has stopped.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="duration" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1096">snap-back animation duration in milliseconds</doc>
+            <type name="gint64" c:type="gint64"/>
+          </parameter>
+          <parameter name="to" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1097">the progress value to animate to</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="update-swipe" when="first" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipe-tracker.c"
+             line="1074">This signal is emitted every time the progress value changes.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="progress" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipe-tracker.c"
+                 line="1077">the current animation progress value</doc>
+            <type name="gdouble" c:type="gdouble"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </class>
+    <record name="SwipeTrackerClass"
+            c:type="AdwSwipeTrackerClass"
+            glib:is-gtype-struct-for="SwipeTracker">
+      <source-position filename="../src/adw-swipe-tracker.h" line="23"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <interface name="Swipeable"
+               c:symbol-prefix="swipeable"
+               c:type="AdwSwipeable"
+               version="1.0"
+               glib:type-name="AdwSwipeable"
+               glib:get-type="adw_swipeable_get_type"
+               glib:type-struct="SwipeableInterface">
+      <doc xml:space="preserve"
+           filename="../src/adw-swipeable.c"
+           line="11">An interface for swipeable widgets.
+
+The `AdwSwipeable` interface is implemented by all swipeable widgets.
+
+See [class@Adw.SwipeTracker] for details about implementing it.</doc>
+      <source-position filename="../src/adw-swipeable.h" line="54"/>
+      <prerequisite name="Gtk.Widget"/>
+      <virtual-method name="get_cancel_progress"
+                      invoker="get_cancel_progress"
+                      version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="106">Gets the progress @self will snap back to after the gesture is canceled.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="112">the cancel progress, unitless</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="108">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_distance" invoker="get_distance" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="30">Gets the swipe distance of @self.
+
+This corresponds to how many pixels 1 unit represents.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="38">the swipe distance in pixels</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="32">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_progress" invoker="get_progress" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="83">Gets the current progress of @self.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="45"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="89">the current progress, unitless</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="85">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_snap_points"
+                      invoker="get_snap_points"
+                      version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="55">Gets the snap points of @self.
+
+Each snap point represents a progress value that is considered acceptable to
+end the swipe on.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="43"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="65">the snap points</doc>
+          <array length="0" zero-terminated="0" c:type="double*">
+            <type name="gdouble" c:type="double"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="57">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+          <parameter name="n_snap_points"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="58">location to return the number of the snap points</doc>
+            <type name="gint" c:type="int*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <virtual-method name="get_swipe_area"
+                      invoker="get_swipe_area"
+                      version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="129">Gets the area @self can start a swipe from for the given direction and
+gesture type.
+
+This can be used to restrict swipes to only be possible from a certain area,
+for example, to only allow edge swipes, or to have a draggable element and
+ignore swipes elsewhere.
+
+If not implemented, the default implementation returns the allocation of
+@self, allowing swipes from anywhere.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="47"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="131">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+          <parameter name="navigation_direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="132">the direction of the swipe</doc>
+            <type name="NavigationDirection" c:type="AdwNavigationDirection"/>
+          </parameter>
+          <parameter name="is_drag" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="133">whether the swipe is caused by a dragging gesture</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="rect"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="134">a pointer to a rectangle to store the swipe area</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+        </parameters>
+      </virtual-method>
+      <method name="get_cancel_progress"
+              c:identifier="adw_swipeable_get_cancel_progress"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="106">Gets the progress @self will snap back to after the gesture is canceled.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="67"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="112">the cancel progress, unitless</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="108">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_distance"
+              c:identifier="adw_swipeable_get_distance"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="30">Gets the swipe distance of @self.
+
+This corresponds to how many pixels 1 unit represents.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="38">the swipe distance in pixels</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="32">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_progress"
+              c:identifier="adw_swipeable_get_progress"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="83">Gets the current progress of @self.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="64"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="89">the current progress, unitless</doc>
+          <type name="gdouble" c:type="double"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="85">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_snap_points"
+              c:identifier="adw_swipeable_get_snap_points"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="55">Gets the snap points of @self.
+
+Each snap point represents a progress value that is considered acceptable to
+end the swipe on.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="60"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-swipeable.c"
+               line="65">the snap points</doc>
+          <array length="0" zero-terminated="0" c:type="double*">
+            <type name="gdouble" c:type="double"/>
+          </array>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="57">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+          <parameter name="n_snap_points"
+                     direction="out"
+                     caller-allocates="0"
+                     transfer-ownership="full">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="58">location to return the number of the snap points</doc>
+            <type name="gint" c:type="int*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_swipe_area"
+              c:identifier="adw_swipeable_get_swipe_area"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.c"
+             line="129">Gets the area @self can start a swipe from for the given direction and
+gesture type.
+
+This can be used to restrict swipes to only be possible from a certain area,
+for example, to only allow edge swipes, or to have a draggable element and
+ignore swipes elsewhere.
+
+If not implemented, the default implementation returns the allocation of
+@self, allowing swipes from anywhere.</doc>
+        <source-position filename="../src/adw-swipeable.h" line="70"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="131">a `AdwSwipeable`</doc>
+            <type name="Swipeable" c:type="AdwSwipeable*"/>
+          </instance-parameter>
+          <parameter name="navigation_direction" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="132">the direction of the swipe</doc>
+            <type name="NavigationDirection" c:type="AdwNavigationDirection"/>
+          </parameter>
+          <parameter name="is_drag" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="133">whether the swipe is caused by a dragging gesture</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+          <parameter name="rect"
+                     direction="out"
+                     caller-allocates="1"
+                     transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="134">a pointer to a rectangle to store the swipe area</doc>
+            <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+          </parameter>
+        </parameters>
+      </method>
+    </interface>
+    <record name="SwipeableInterface"
+            c:type="AdwSwipeableInterface"
+            glib:is-gtype-struct-for="Swipeable"
+            version="1.0">
+      <doc xml:space="preserve"
+           filename="../src/adw-swipeable.h"
+           line="25">An interface for swipeable widgets.</doc>
+      <source-position filename="../src/adw-swipeable.h" line="54"/>
+      <field name="parent">
+        <doc xml:space="preserve"
+             filename="../src/adw-swipeable.h"
+             line="27">The parent interface.</doc>
+        <type name="GObject.TypeInterface" c:type="GTypeInterface"/>
+      </field>
+      <field name="get_distance">
+        <callback name="get_distance">
+          <source-position filename="../src/adw-swipeable.h" line="42"/>
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="38">the swipe distance in pixels</doc>
+            <type name="gdouble" c:type="double"/>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="32">a `AdwSwipeable`</doc>
+              <type name="Swipeable" c:type="AdwSwipeable*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_snap_points">
+        <callback name="get_snap_points">
+          <source-position filename="../src/adw-swipeable.h" line="43"/>
+          <return-value transfer-ownership="full">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="65">the snap points</doc>
+            <array length="1" zero-terminated="0" c:type="double*">
+              <type name="gdouble" c:type="double"/>
+            </array>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="57">a `AdwSwipeable`</doc>
+              <type name="Swipeable" c:type="AdwSwipeable*"/>
+            </parameter>
+            <parameter name="n_snap_points"
+                       direction="out"
+                       caller-allocates="0"
+                       transfer-ownership="full">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="58">location to return the number of the snap points</doc>
+              <type name="gint" c:type="int*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_progress">
+        <callback name="get_progress">
+          <source-position filename="../src/adw-swipeable.h" line="45"/>
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="89">the current progress, unitless</doc>
+            <type name="gdouble" c:type="double"/>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="85">a `AdwSwipeable`</doc>
+              <type name="Swipeable" c:type="AdwSwipeable*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_cancel_progress">
+        <callback name="get_cancel_progress">
+          <source-position filename="../src/adw-swipeable.h" line="46"/>
+          <return-value transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-swipeable.c"
+                 line="112">the cancel progress, unitless</doc>
+            <type name="gdouble" c:type="double"/>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="108">a `AdwSwipeable`</doc>
+              <type name="Swipeable" c:type="AdwSwipeable*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="get_swipe_area">
+        <callback name="get_swipe_area">
+          <source-position filename="../src/adw-swipeable.h" line="47"/>
+          <return-value transfer-ownership="none">
+            <type name="none" c:type="void"/>
+          </return-value>
+          <parameters>
+            <parameter name="self" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="131">a `AdwSwipeable`</doc>
+              <type name="Swipeable" c:type="AdwSwipeable*"/>
+            </parameter>
+            <parameter name="navigation_direction" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="132">the direction of the swipe</doc>
+              <type name="NavigationDirection"
+                    c:type="AdwNavigationDirection"/>
+            </parameter>
+            <parameter name="is_drag" transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="133">whether the swipe is caused by a dragging gesture</doc>
+              <type name="gboolean" c:type="gboolean"/>
+            </parameter>
+            <parameter name="rect"
+                       direction="out"
+                       caller-allocates="1"
+                       transfer-ownership="none">
+              <doc xml:space="preserve"
+                   filename="../src/adw-swipeable.c"
+                   line="134">a pointer to a rectangle to store the swipe area</doc>
+              <type name="Gdk.Rectangle" c:type="GdkRectangle*"/>
+            </parameter>
+          </parameters>
+        </callback>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="TabBar"
+           c:symbol-prefix="tab_bar"
+           c:type="AdwTabBar"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwTabBar"
+           glib:get-type="adw_tab_bar_get_type"
+           glib:type-struct="TabBarClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-tab-bar.c"
+           line="17">A tab bar for [class@Adw.TabView].
+
+The `AdwTabBar` widget is a tab bar that can be used with conjunction with
+`AdwTabView`.
+
+`AdwTabBar` can autohide and can optionally contain action widgets on both
+sides of the tabs.
+
+When there's not enough space to show all the tabs, `AdwTabBar` will scroll
+them. Pinned tabs always stay visible and aren't a part of the scrollable
+area.
+
+## CSS nodes
+
+`AdwTabBar` has a single CSS node with name `tabbar`.</doc>
+      <source-position filename="../src/adw-tab-bar.h" line="26"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_tab_bar_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="686">Creates a new `AdwTabBar`.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="29"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="691">the newly created `AdwTabBar`</doc>
+          <type name="TabBar" c:type="AdwTabBar*"/>
+        </return-value>
+      </constructor>
+      <method name="get_autohide"
+              c:identifier="adw_tab_bar_get_autohide"
+              glib:get-property="autohide"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="autohide"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="891">Gets whether the tabs automatically hide.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="50"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="897">whether the tabs automatically hide</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="893">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_end_action_widget"
+              c:identifier="adw_tab_bar_get_end_action_widget"
+              glib:get-property="end-action-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="end-action-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="844">Gets the widget shown after the tabs.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="44"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="850">the widget shown after the tabs</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="846">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_expand_tabs"
+              c:identifier="adw_tab_bar_get_expand_tabs"
+              glib:get-property="expand-tabs"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="expand-tabs"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="954">Gets whether tabs expand to full width.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="59"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="960">whether tabs expand to full width.</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="956">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_inverted"
+              c:identifier="adw_tab_bar_get_inverted"
+              glib:get-property="inverted"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="inverted"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="997">Gets whether tabs use inverted layout.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="65"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="1003">whether tabs use inverted layout</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="999">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_is_overflowing"
+              c:identifier="adw_tab_bar_get_is_overflowing"
+              glib:get-property="is-overflowing"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="is-overflowing"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="1076">Gets whether @self is overflowing.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="77"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="1082">whether @self is overflowing</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1078">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_start_action_widget"
+              c:identifier="adw_tab_bar_get_start_action_widget"
+              glib:get-property="start-action-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="start-action-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="797">Gets the widget shown before the tabs.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="38"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="803">the widget shown before the tabs</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="799">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tabs_revealed"
+              c:identifier="adw_tab_bar_get_tabs_revealed"
+              glib:get-property="tabs-revealed"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="tabs-revealed"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="936">Gets whether the tabs are currently revealed.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="56"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="942">whether the tabs are currently revealed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="938">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_view"
+              c:identifier="adw_tab_bar_get_view"
+              glib:get-property="view"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="view"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="701">Gets the tab view @self controls.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="32"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="707">the view @self controls</doc>
+          <type name="TabView" c:type="AdwTabView*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="703">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_autohide"
+              c:identifier="adw_tab_bar_set_autohide"
+              glib:set-property="autohide"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="autohide"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="909">Sets whether the tabs automatically hide.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="52"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="911">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="autohide" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="912">whether the tabs automatically hide</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_end_action_widget"
+              c:identifier="adw_tab_bar_set_end_action_widget"
+              glib:set-property="end-action-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="end-action-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="862">Sets the widget to show after the tabs.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="864">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="865">the widget to show after the tabs</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_expand_tabs"
+              c:identifier="adw_tab_bar_set_expand_tabs"
+              glib:set-property="expand-tabs"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="expand-tabs"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="972">Sets whether tabs expand to full width.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="61"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="974">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="expand_tabs" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="975">whether to expand tabs</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_inverted"
+              c:identifier="adw_tab_bar_set_inverted"
+              glib:set-property="inverted"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="inverted"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="1015">Sets whether tabs tabs use inverted layout.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="67"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1017">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="inverted" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1018">whether tabs use inverted layout</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_start_action_widget"
+              c:identifier="adw_tab_bar_set_start_action_widget"
+              glib:set-property="start-action-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="start-action-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="815">Sets the widget to show before the tabs.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="817">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="818">the widget to show before the tabs</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_view"
+              c:identifier="adw_tab_bar_set_view"
+              glib:set-property="view"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="view"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="719">Sets the tab view @self controls.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="721">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="view"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="722">a tab view</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="setup_extra_drop_target"
+              c:identifier="adw_tab_bar_setup_extra_drop_target"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="1040">Sets the supported types for this drop target.
+
+Sets up an extra drop target on tabs.
+
+This allows to drag arbitrary content onto tabs, for example URLs in a web
+browser.
+
+If a tab is hovered for a certain period of time while dragging the content,
+it will be automatically selected.
+
+The [signal@Adw.TabBar::extra-drag-drop] signal can be used to handle the
+drop.</doc>
+        <source-position filename="../src/adw-tab-bar.h" line="71"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1042">a `AdwTabBar`</doc>
+            <type name="TabBar" c:type="AdwTabBar*"/>
+          </instance-parameter>
+          <parameter name="actions" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1043">the supported actions</doc>
+            <type name="Gdk.DragAction" c:type="GdkDragAction"/>
+          </parameter>
+          <parameter name="types"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1044">
+  all supported `GType`s that can be dropped</doc>
+            <array length="2" zero-terminated="0" c:type="GType*">
+              <type name="GType" c:type="GType"/>
+            </array>
+          </parameter>
+          <parameter name="n_types" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="1046">number of @types</doc>
+            <type name="gsize" c:type="gsize"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="autohide"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_autohide"
+                getter="get_autohide">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_autohide"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_bar_set_autohide"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="483">Whether the tabs automatically hide.
+
+If set to `TRUE`, the tab bar disappears when [property@Adw.TabBar:view]
+has 0 or 1 tab, no pinned tabs, and no tab is being transferred.
+
+See [property@Adw.TabBar:tabs-revealed].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="end-action-widget"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_end_action_widget"
+                getter="get_end_action_widget">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_end_action_widget"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_bar_set_end_action_widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="469">The widget shown after the tabs.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="expand-tabs"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_expand_tabs"
+                getter="get_expand_tabs">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_expand_tabs"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_bar_set_expand_tabs"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="518">Whether tabs expand to full width.
+
+If set to `TRUE`, the tabs will always vary width filling the whole width
+when possible, otherwise tabs will always have the minimum possible size.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="inverted"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_inverted"
+                getter="get_inverted">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_inverted"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_bar_set_inverted"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="535">Whether tabs use inverted layout.
+
+If set to `TRUE`, non-pinned tabs will have the close button at the
+beginning and the indicator at the end rather than the opposite.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="is-overflowing"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_is_overflowing">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_is_overflowing"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="552">Whether the tab bar is overflowing.
+
+If `TRUE`, all tabs cannot be displayed at once and require scrolling.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="start-action-widget"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_start_action_widget"
+                getter="get_start_action_widget">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_start_action_widget"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_bar_set_start_action_widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="455">The widget shown before the tabs.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="tabs-revealed"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_tabs_revealed">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_bar_get_tabs_revealed"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="502">Whether the tabs are currently revealed.
+
+See [property@Adw.TabBar:autohide].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="view"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_view"
+                getter="get_view">
+        <attribute name="org.gtk.Property.get" value="adw_tab_bar_get_view"/>
+        <attribute name="org.gtk.Property.set" value="adw_tab_bar_set_view"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="441">The tab view the tab bar controls.</doc>
+        <type name="TabView"/>
+      </property>
+      <glib:signal name="extra-drag-drop" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-bar.c"
+             line="570">This signal is emitted when content is dropped onto a tab.
+
+The content must be of one of the types set up via
+[method@Adw.TabBar.setup_extra_drop_target].
+
+See [signal@Gtk.DropTarget::drop].</doc>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-bar.c"
+               line="583">whether the drop was accepted for @page</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="573">the page matching the tab the content was dropped onto</doc>
+            <type name="TabPage"/>
+          </parameter>
+          <parameter name="value" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-bar.c"
+                 line="574">the `GValue` being dropped</doc>
+            <type name="GObject.Value"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </class>
+    <record name="TabBarClass"
+            c:type="AdwTabBarClass"
+            glib:is-gtype-struct-for="TabBar">
+      <source-position filename="../src/adw-tab-bar.h" line="26"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="TabPage"
+           c:symbol-prefix="tab_page"
+           c:type="AdwTabPage"
+           parent="GObject.Object"
+           glib:type-name="AdwTabPage"
+           glib:get-type="adw_tab_page_get_type"
+           glib:type-struct="TabPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-tab-view.c"
+           line="49">An auxiliary class used by [class@Adw.TabView].</doc>
+      <source-position filename="../src/adw-tab-view.h" line="24"/>
+      <method name="get_child"
+              c:identifier="adw_tab_page_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1778">Gets the child of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="27"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1784">the child of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1780">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon"
+              c:identifier="adw_tab_page_get_icon"
+              glib:get-property="icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1934">Gets the icon of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="51"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1940">the icon of @self</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1936">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_indicator_activatable"
+              c:identifier="adw_tab_page_get_indicator_activatable"
+              glib:get-property="indicator-activatable"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="indicator-activatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2061">Gets whether the indicator of @self is activatable.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="69"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2068">whether the indicator is activatable</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2063">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_indicator_icon"
+              c:identifier="adw_tab_page_get_indicator_icon"
+              glib:get-property="indicator-icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="indicator-icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2019">Gets the indicator icon of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="63"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2025">the indicator icon of @self</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2021">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_loading"
+              c:identifier="adw_tab_page_get_loading"
+              glib:get-property="loading"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="loading"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1976">Gets whether @self is loading.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="57"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1982">whether @self is loading</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1978">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_needs_attention"
+              c:identifier="adw_tab_page_get_needs_attention"
+              glib:get-property="needs-attention"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="needs-attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2105">Gets whether @self needs attention.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="75"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2111">whether @self needs attention</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2107">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_parent"
+              c:identifier="adw_tab_page_get_parent"
+              glib:get-property="parent"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="parent"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1796">Gets the parent page of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="30"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1802">the parent page</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1798">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_pinned"
+              c:identifier="adw_tab_page_get_pinned"
+              glib:get-property="pinned"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="pinned"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1832">Gets whether @self is pinned.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1838">whether @self is pinned</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1834">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_selected"
+              c:identifier="adw_tab_page_get_selected"
+              glib:get-property="selected"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="selected"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1814">Gets whether @self is selected.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1820">whether @self is selected</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1816">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_tab_page_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1850">Gets the title of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1856">the title of @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1852">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_tooltip"
+              c:identifier="adw_tab_page_get_tooltip"
+              glib:get-property="tooltip"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="tooltip"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1892">Gets the tooltip of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="45"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1898">the tooltip of @self</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1894">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_icon"
+              c:identifier="adw_tab_page_set_icon"
+              glib:set-property="icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1952">Sets the icon of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="53"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1954">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1955">the icon of @self</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_indicator_activatable"
+              c:identifier="adw_tab_page_set_indicator_activatable"
+              glib:set-property="indicator-activatable"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="indicator-activatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2080">Sets whether the indicator of @self is activatable.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="71"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2082">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="activatable" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2083">whether the indicator is activatable</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_indicator_icon"
+              c:identifier="adw_tab_page_set_indicator_icon"
+              glib:set-property="indicator-icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="indicator-icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2037">Sets the indicator icon of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="65"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2039">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="indicator_icon"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2040">the indicator icon of @self</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_loading"
+              c:identifier="adw_tab_page_set_loading"
+              glib:set-property="loading"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="loading"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1994">Sets wether @self is loading.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="59"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1996">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="loading" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1997">whether @self is loading</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_needs_attention"
+              c:identifier="adw_tab_page_set_needs_attention"
+              glib:set-property="needs-attention"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="needs-attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2123">Sets whether @self needs attention.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="77"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2125">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="needs_attention" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2126">whether @self needs attention</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_tab_page_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1868">Sets the title of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="41"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1870">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1871">the title of @self</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_tooltip"
+              c:identifier="adw_tab_page_set_tooltip"
+              glib:set-property="tooltip"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="tooltip"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1910">Sets the tooltip of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="47"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1912">a `AdwTabPage`</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </instance-parameter>
+          <parameter name="tooltip" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1913">the tooltip of @self</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get" value="adw_tab_page_get_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="360">The child of the page.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="icon"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon"
+                getter="get_icon">
+        <attribute name="org.gtk.Property.get" value="adw_tab_page_get_icon"/>
+        <attribute name="org.gtk.Property.set" value="adw_tab_page_set_icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="457">The icon of the page.
+
+[class@Adw.TabBar] displays the icon next to the title.
+
+It will not show the icon if [property@Adw.TabPage:loading] is set to
+`TRUE`, or if the page is pinned and [property@Adw.TabPage:indicator-icon]
+is set.</doc>
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="indicator-activatable"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_indicator_activatable"
+                getter="get_indicator_activatable">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_indicator_activatable"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_page_set_indicator_activatable"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="522">Whether the indicator icon is activatable.
+
+If set to `TRUE`, [signal@Adw.TabView::indicator-activated] will be emitted
+when the indicator icon is clicked.
+
+If [property@Adw.TabPage:indicator-icon] is not set, does nothing.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="indicator-icon"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_indicator_icon"
+                getter="get_indicator_icon">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_indicator_icon"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_page_set_indicator_icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="497">An indicator icon for the page.
+
+A common use case is an audio or camera indicator in a web browser.
+
+[class@Adw.TabBar] will show it at the beginning of the tab, alongside icon
+representing [property@Adw.TabPage:icon] or loading spinner.
+
+If the page is pinned, the indicator will be shown instead of icon or
+spinner.
+
+If [property@Adw.TabPage:indicator-activatable] is set to `TRUE`, the
+indicator icon can act as a button.</doc>
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="loading"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_loading"
+                getter="get_loading">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_loading"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_page_set_loading"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="477">Whether the page is loading.
+
+If set to `TRUE`, [class@Adw.TabBar] will display a spinner in place of
+icon.
+
+If the page is pinned and [property@Adw.TabPage:indicator-icon] is set, the
+loading status will not be visible.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="needs-attention"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_needs_attention"
+                getter="get_needs_attention">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_needs_attention"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_page_set_needs_attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="541">Whether the page needs attention.
+
+[class@Adw.TabBar] will display a glow under the tab representing the page
+if set to `TRUE`. If the tab is not visible, the corresponding edge of the
+tab bar will be highlighted.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="parent"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_parent">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_parent"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="374">The parent page of the page.
+
+See [method@Adw.TabView.add_page] and [method@Adw.TabView.close_page].</doc>
+        <type name="TabPage"/>
+      </property>
+      <property name="pinned"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_pinned">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_pinned"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="404">Whether the page is pinned.
+
+See [method@Adw.TabView.set_page_pinned].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="selected"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_selected">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_selected"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="390">Whether the page is selected.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get" value="adw_tab_page_get_title"/>
+        <attribute name="org.gtk.Property.set" value="adw_tab_page_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="420">The title of the page.
+
+[class@Adw.TabBar] will display it in the center of the tab unless it's
+pinned, and will use it as a tooltip unless [property@Adw.TabPage:tooltip]
+is set.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="tooltip"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_tooltip"
+                getter="get_tooltip">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_page_get_tooltip"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_page_set_tooltip"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="438">The tooltip of the page.
+
+The tooltip can be marked up with the Pango text markup language.
+
+If not set, [class@Adw.TabBar] will use [property@Adw.TabPage:title] as a
+tooltip instead.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="TabPageClass"
+            c:type="AdwTabPageClass"
+            glib:is-gtype-struct-for="TabPage">
+      <source-position filename="../src/adw-tab-view.h" line="24"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <class name="TabView"
+           c:symbol-prefix="tab_view"
+           c:type="AdwTabView"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwTabView"
+           glib:get-type="adw_tab_view_get_type"
+           glib:type-struct="TabViewClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-tab-view.c"
+           line="19">A dynamic tabbed container.
+
+`AdwTabView` is a container which shows one child at a time. While it
+provides keyboard shortcuts for switching between pages, it does not provide
+a visible tab bar and relies on external widgets for that, such as
+[class@Adw.TabBar].
+
+`AdwTabView` maintains a [class@Adw.TabPage] object for each page, which
+holds additional per-page properties. You can obtain the `AdwTabPage` for a
+page with [method@Adw.TabView.get_page], and as the return value for
+[method@Adw.TabView.append] and other functions for adding children.
+
+`AdwTabView` only aims to be useful for dynamic tabs in multi-window
+document-based applications, such as web browsers, file managers, text
+editors or terminals. It does not aim to replace [class@Gtk.Notebook] for use
+cases such as tabbed dialogs.
+
+As such, it does not support disabling page reordering or detaching, or
+adding children via [class@Gtk.Builder].
+
+## CSS nodes
+
+`AdwTabView` has a main CSS node with the name `tabview`.</doc>
+      <source-position filename="../src/adw-tab-view.h" line="83"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_tab_view_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2148">Creates a new `AdwTabView`.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="86"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2153">the newly created `AdwTabView`</doc>
+          <type name="TabView" c:type="AdwTabView*"/>
+        </return-value>
+      </constructor>
+      <method name="add_page"
+              c:identifier="adw_tab_view_add_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2699">Adds @child to @self with @parent as the parent.
+
+This function can be used to automatically position new pages, and to select
+the correct page when this page is closed while being selected (see
+[method@Adw.TabView.close_page]).
+
+If @parent is `NULL`, this function is equivalent to
+[method@Adw.TabView.append].</doc>
+        <source-position filename="../src/adw-tab-view.h" line="143"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2714">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2701">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2702">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="parent"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2703">a parent page for @child</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="append" c:identifier="adw_tab_view_append" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2803">Inserts @child as the last non-pinned page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="155"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2810">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2805">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2806">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="append_pinned"
+              c:identifier="adw_tab_view_append_pinned"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2873">Inserts @child as the last pinned page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="166"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2880">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2875">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2876">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_other_pages"
+              c:identifier="adw_tab_view_close_other_pages"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2974">Requests to close all pages other than @page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="178"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2976">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2977">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_page"
+              c:identifier="adw_tab_view_close_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2894">Requests to close @page.
+
+Calling this function will result in the [signal@Adw.TabView::close-page]
+signal being emitted for @page. Closing the page can then be confirmed or
+denied via [method@Adw.TabView.close_page_finish].
+
+If the page is waiting for a [method@Adw.TabView.close_page_finish] call,
+this function will do nothing.
+
+The default handler for [signal@Adw.TabView::close-page] will immediately
+confirm closing the page if it's non-pinned, or reject it if it's pinned.
+This behavior can be changed by registering your own handler for that signal.
+
+If @page was selected, another page will be selected instead:
+
+If the [property@Adw.TabPage:parent] value is `NULL`, the next page will be
+selected when possible, or if the page was already last, the previous page
+will be selected instead.
+
+If it's not `NULL`, the previous page will be selected if it's a descendant
+(possibly indirect) of the parent. If both the previous page and the parent
+are pinned, the parent will be selected instead.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="170"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2896">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2897">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_page_finish"
+              c:identifier="adw_tab_view_close_page_finish"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2941">Completes a [method@Adw.TabView.close_page] call for @page.
+
+If @confirm is `TRUE`, @page will be closed. If it's `FALSE`, it will be
+reverted to its previous state and [method@Adw.TabView.close_page] can be
+called for it again.
+
+This function should not be called unless a custom handler for
+[signal@Adw.TabView::close-page] is used.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="173"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2943">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2944">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+          <parameter name="confirm" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2945">whether to confirm or deny closing @page</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_pages_after"
+              c:identifier="adw_tab_view_close_pages_after"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3031">Requests to close all pages after @page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="184"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3033">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3034">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="close_pages_before"
+              c:identifier="adw_tab_view_close_pages_before"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3003">Requests to close all pages before @page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="181"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3005">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3006">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_default_icon"
+              c:identifier="adw_tab_view_get_default_icon"
+              glib:get-property="default-icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="default-icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2388">Gets the default icon of @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="108"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2394">the default icon of @self.</doc>
+          <type name="Gio.Icon" c:type="GIcon*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2390">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_is_transferring_page"
+              c:identifier="adw_tab_view_get_is_transferring_page"
+              glib:get-property="is-transferring-page"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="is-transferring-page"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2199">Whether a page is being transferred.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="94"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2205">whether a page is being transferred</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2201">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_menu_model"
+              c:identifier="adw_tab_view_get_menu_model"
+              glib:get-property="menu-model"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="menu-model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2430">Gets the tab context menu model for @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="114"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2436">the tab context menu model for @self</doc>
+          <type name="Gio.MenuModel" c:type="GMenuModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2432">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_n_pages"
+              c:identifier="adw_tab_view_get_n_pages"
+              glib:get-property="n-pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="n-pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2163">Gets the number of pages in @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="89"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2169">the number of pages in @self</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2165">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_n_pinned_pages"
+              c:identifier="adw_tab_view_get_n_pinned_pages"
+              glib:get-property="n-pinned-pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="n-pinned-pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2181">Gets the number of pinned pages in @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="91"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2187">the number of pinned pages in @self</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2183">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_nth_page"
+              c:identifier="adw_tab_view_get_nth_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2642">Gets the [class@Adw.TabPage] representing the child at @position.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="135"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2649">the page object at @position</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2644">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2645">the index of the page in @self, starting from 0</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_page"
+              c:identifier="adw_tab_view_get_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2611">Gets the [class@Adw.TabPage] object representing @child.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="131"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2618">the page object for @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2613">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2614">a child in @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_page_position"
+              c:identifier="adw_tab_view_get_page_position"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2668">Finds the position of @page in @self, starting from 0.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="139"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2675">the position of @page in @self</doc>
+          <type name="gint" c:type="int"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2670">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2671">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_pages"
+              c:identifier="adw_tab_view_get_pages"
+              glib:get-property="pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3317">Returns a [iface@Gio.ListModel] that contains the pages of @self.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the selected
+page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="211"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3327">a `GtkSelectionModel` for the pages of @self</doc>
+          <type name="Gtk.SelectionModel" c:type="GtkSelectionModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3319">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_selected_page"
+              c:identifier="adw_tab_view_get_selected_page"
+              glib:get-property="selected-page"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="selected-page"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2217">Gets the currently selected page in @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="97"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2223">the selected page</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2219">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_shortcut_widget"
+              c:identifier="adw_tab_view_get_shortcut_widget"
+              glib:get-property="shortcut-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="shortcut-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2472">Gets the shortcut widget for @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="120"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2478">the shortcut widget for @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2474">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="insert" c:identifier="adw_tab_view_insert" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2754">Inserts a non-pinned page at @position.
+
+It's an error to try to insert a page before a pinned page, in that case
+[method@Adw.TabView.insert_pinned] should be used instead.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="148"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2765">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2756">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2757">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2758">the position to add @child at, starting from 0</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="insert_pinned"
+              c:identifier="adw_tab_view_insert_pinned"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2824">Inserts a pinned page at @position.
+
+It's an error to try to insert a pinned page after a non-pinned page, in
+that case [method@Adw.TabView.insert] should be used instead.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="159"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2835">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2826">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2827">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2828">the position to add @child at, starting from 0</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="prepend" c:identifier="adw_tab_view_prepend" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2782">Inserts @child as the first non-pinned page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="152"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2789">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2784">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2785">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="prepend_pinned"
+              c:identifier="adw_tab_view_prepend_pinned"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2852">Inserts @child as the first pinned page.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="163"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2859">the page object representing @child</doc>
+          <type name="TabPage" c:type="AdwTabPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2854">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2855">a widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_backward"
+              c:identifier="adw_tab_view_reorder_backward"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3117">Reorders @page to before its previous page if possible.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="192"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3124">whether @page was moved</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3119">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3120">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_first"
+              c:identifier="adw_tab_view_reorder_first"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3183">Reorders @page to the first possible position.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="198"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3190">whether @page was moved</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3185">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3186">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_forward"
+              c:identifier="adw_tab_view_reorder_forward"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3150">Reorders @page to after its next page if possible.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="195"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3157">whether @page was moved</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3152">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3153">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_last"
+              c:identifier="adw_tab_view_reorder_last"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3211">Reorders @page to the last possible position.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="201"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3218">whether @page was moved</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3213">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3214">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="reorder_page"
+              c:identifier="adw_tab_view_reorder_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3059">Reorders @page to @position.
+
+It's a programmer error to try to reorder a pinned page after a non-pinned
+one, or a non-pinned page before a pinned one.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="188"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="3070">whether @page was moved</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3061">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3062">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3063">the position to insert the page at, starting at 0</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="select_next_page"
+              c:identifier="adw_tab_view_select_next_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2295">Selects the page after the currently selected page.
+
+If the last page was already selected, this function does nothing.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="105"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2303">whether the selected page was changed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2297">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="select_previous_page"
+              c:identifier="adw_tab_view_select_previous_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2260">Selects the page before the currently selected page.
+
+If the first page was already selected, this function does nothing.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="103"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="2268">whether the selected page was changed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2262">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_default_icon"
+              c:identifier="adw_tab_view_set_default_icon"
+              glib:set-property="default-icon"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="default-icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2406">Sets the default page icon for @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="110"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2408">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="default_icon" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2409">the default icon</doc>
+            <type name="Gio.Icon" c:type="GIcon*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_menu_model"
+              c:identifier="adw_tab_view_set_menu_model"
+              glib:set-property="menu-model"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="menu-model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2448">Sets the tab context menu model for @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="116"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2450">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="menu_model"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2451">a menu model</doc>
+            <type name="Gio.MenuModel" c:type="GMenuModel*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_page_pinned"
+              c:identifier="adw_tab_view_set_page_pinned"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2535">Pins or unpins @page.
+
+Pinned pages are guaranteed to be placed before all non-pinned pages; at any
+given moment the first [property@Adw.TabView:n-pinned-pages] pages in @self
+are guaranteed to be pinned.
+
+When a page is pinned or unpinned, it's automatically reordered: pinning a
+page moves it after other pinned pages; unpinning a page moves it before
+other non-pinned pages.
+
+Pinned pages can still be reordered between each other.
+
+[class@Adw.TabBar] will display pinned pages in a compact form, never showing
+the title or close button, and only showing a single icon, selected in the
+following order:
+
+1. [property@Adw.TabPage:indicator-icon]
+2. A spinner if [property@Adw.TabPage:loading] is `TRUE`
+3. [property@Adw.TabPage:icon]
+4. [property@Adw.TabView:default-icon]
+
+Pinned pages cannot be closed by default, see
+[signal@Adw.TabView::close-page] for how to override that behavior.
+
+Changes the value of the [property@Adw.TabPage:pinned] property.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="126"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2537">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2538">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+          <parameter name="pinned" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2539">whether @page should be pinned</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_selected_page"
+              c:identifier="adw_tab_view_set_selected_page"
+              glib:set-property="selected-page"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="selected-page"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2235">Sets the currently selected page in @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="99"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2237">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="selected_page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2238">a page in @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_shortcut_widget"
+              c:identifier="adw_tab_view_set_shortcut_widget"
+              glib:set-property="shortcut-widget"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="shortcut-widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="2490">Sets the shortcut widget for @self.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="122"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2492">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="widget"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="2493">a shortcut widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="transfer_page"
+              c:identifier="adw_tab_view_transfer_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="3277">Transfers @page from @self to @other_view.
+
+The @page object will be reused.
+
+It's a programmer error to try to insert a pinned page after a non-pinned
+one, or a non-pinned page before a pinned one.</doc>
+        <source-position filename="../src/adw-tab-view.h" line="205"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3279">a `AdwTabView`</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </instance-parameter>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3280">a page of @self</doc>
+            <type name="TabPage" c:type="AdwTabPage*"/>
+          </parameter>
+          <parameter name="other_view" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3281">the tab view to transfer the page to</doc>
+            <type name="TabView" c:type="AdwTabView*"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="3282">the position to insert the page at, starting at 0</doc>
+            <type name="gint" c:type="int"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="default-icon"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_default_icon"
+                getter="get_default_icon">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_default_icon"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_view_set_default_icon"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1464">Default page icon.
+
+If a page doesn't provide its own icon via [property@Adw.TabPage:icon],
+a default icon may be used instead for contexts where having an icon is
+necessary.
+
+[class@Adw.TabBar] will use default icon for pinned tabs in case the page
+is not loading, doesn't have an icon and an indicator. Default icon is
+never used for tabs that aren't pinned.
+
+By default, the `adw-tab-icon-missing-symbolic` icon is used.</doc>
+        <type name="Gio.Icon"/>
+      </property>
+      <property name="is-transferring-page"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_is_transferring_page">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_is_transferring_page"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1430">Whether a page is being transferred.
+
+This property will be set to `TRUE` when a drag-n-drop tab transfer starts
+on any `AdwTabView`, and to `FALSE` after it ends.
+
+During the transfer, children cannot receive pointer input and a tab can
+be safely dropped on the tab view.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="menu-model"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_menu_model"
+                getter="get_menu_model">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_menu_model"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_view_set_menu_model"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1488">Tab context menu model.
+
+When a context menu is shown for a tab, it will be constructed from the
+provided menu model. Use the [signal@Adw.TabView::setup-menu] signal to set
+up the menu actions for the particular tab.</doc>
+        <type name="Gio.MenuModel"/>
+      </property>
+      <property name="n-pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_n_pages">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_n_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1400">The number of pages in the tab view.</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="n-pinned-pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_n_pinned_pages">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_n_pinned_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1414">The number of pinned pages in the tab view.
+
+See [method@Adw.TabView.set_page_pinned].</doc>
+        <type name="gint" c:type="gint"/>
+      </property>
+      <property name="pages"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_pages">
+        <attribute name="org.gtk.Property.get" value="adw_tab_view_get_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1537">A selection model with the tab view's pages.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the selected
+page.</doc>
+        <type name="Gtk.SelectionModel"/>
+      </property>
+      <property name="selected-page"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_selected_page"
+                getter="get_selected_page">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_selected_page"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_view_set_selected_page"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1450">The currently selected page.</doc>
+        <type name="TabPage"/>
+      </property>
+      <property name="shortcut-widget"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_shortcut_widget"
+                getter="get_shortcut_widget">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_tab_view_get_shortcut_widget"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_tab_view_set_shortcut_widget"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1506">The shortcut widget.
+
+It has the following shortcuts:
+* Ctrl+Page Up - switch to the previous page
+* Ctrl+Page Down - switch to the next page
+* Ctrl+Home - switch to the first page
+* Ctrl+End - switch to the last page
+* Ctrl+Shift+Page Up - move the current page backward
+* Ctrl+Shift+Page Down - move the current page forward
+* Ctrl+Shift+Home - move the current page at the start
+* Ctrl+Shift+End - move the current page at the end
+* Ctrl+Tab - switch to the next page, with looping
+* Ctrl+Shift+Tab - switch to the previous page, with looping
+* Alt+1-9 - switch to pages 1-9
+* Alt+0 - switch to page 10
+
+These shortcuts are always available on the tab view itself, this property
+is useful if they should be available globally.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <glib:signal name="close-page" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1628">Emitted after [method@Adw.TabView.close_page] has been called for
+@page.
+
+The handler is expected to call [method@Adw.TabView.close_page_finish] to
+confirm or reject the closing.
+
+The default handler will immediately confirm closing for non-pinned pages,
+or reject it for pinned pages, equivalent to the following example:
+
+```c
+static gboolean
+close_page_cb (AdwTabView *view,
+               AdwTabPage *page,
+               gpointer    user_data)
+{
+  adw_tab_view_close_page_finish (view, page, !adw_tab_page_get_pinned (page));
+
+  return GDK_EVENT_STOP;
+}
+```
+
+The [method@Adw.TabView.close_page_finish] call doesn't have to happen
+inside the handler, so can be used to do asynchronous checks before
+confirming the closing.
+
+A typical reason to connect to this signal is to show a confirmation dialog
+for closing a tab.</doc>
+        <return-value transfer-ownership="none">
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1631">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="create-window" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1698">Emitted when a tab should be transferred into a new window.
+
+This can happen after a tab has been dropped on desktop.
+
+The signal handler is expected to create a new window, position it as
+needed and return its `AdwTabView` that the page will be transferred into.</doc>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-tab-view.c"
+               line="1709">the `AdwTabView` from the new window</doc>
+          <type name="TabView"/>
+        </return-value>
+      </glib:signal>
+      <glib:signal name="indicator-activated" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1723">Emitted after the indicator icon on @page has been activated.
+
+See [property@Adw.TabPage:indicator-icon] and
+[property@Adw.TabPage:indicator-activatable].</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1726">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="page-attached" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1557">Emitted when a page has been created or transferred to @self.
+
+A typical reason to connect to this signal would be to connect to page
+signals for things such as updating window title.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1560">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1561">the position of the page, starting from 0</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="page-detached" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1580">Emitted when a page has been removed or transferred to another view.
+
+A typical reason to connect to this signal would be to disconnect signal
+handlers connected in the [signal@Adw.TabView::page-attached] handler.
+
+It is important not to try and destroy the page child in the handler of
+this function as the child might merely be moved to another window; use
+child dispose handler for that or do it in sync with your
+[method@Adw.TabView.close_page_finish] calls.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1583">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1584">the position of the removed page, starting from 0</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="page-reordered" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1608">Emitted after @page has been reordered to @position.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="page" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1611">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+          <parameter name="position" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1612">the position @page was moved to, starting at 0</doc>
+            <type name="gint" c:type="gint"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <glib:signal name="setup-menu" when="last" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-tab-view.c"
+             line="1674">Emitted when a context menu is opened or closed for @page.
+
+If the menu has been closed, @page will be set to `NULL`.
+
+It can be used to set up menu actions before showing the menu, for example
+disable actions not applicable to @page.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="page"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-tab-view.c"
+                 line="1677">a page of @self</doc>
+            <type name="TabPage"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </class>
+    <record name="TabViewClass"
+            c:type="AdwTabViewClass"
+            glib:is-gtype-struct-for="TabView">
+      <source-position filename="../src/adw-tab-view.h" line="83"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <function-macro name="UNAVAILABLE"
+                    c:identifier="ADW_UNAVAILABLE"
+                    introspectable="0">
+      <source-position filename="../src/adw-version.h" line="87"/>
+      <parameters>
+        <parameter name="major">
+        </parameter>
+        <parameter name="minor">
+        </parameter>
+      </parameters>
+    </function-macro>
+    <constant name="VERSION_S" value="1.0.0.alpha.4" c:type="ADW_VERSION_S">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.h"
+           line="45">Adwaita version, encoded as a string, useful for printing and
+concatenation.</doc>
+      <source-position filename="../src/adw-version.h" line="51"/>
+      <type name="utf8" c:type="gchar*"/>
+    </constant>
+    <class name="ViewStack"
+           c:symbol-prefix="view_stack"
+           c:type="AdwViewStack"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwViewStack"
+           glib:get-type="adw_view_stack_get_type"
+           glib:type-struct="ViewStackClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-stack.c"
+           line="24">A view container for [class@Adw.ViewSwitcher].
+
+`AdwViewStack` is a container which only shows one page at a time.
+It is typically used to hold an application's main views.
+
+It doesn't provide a way to transition between pages.
+Instead, a separate widget such as [class@Adw.ViewSwitcher] can be used with
+`AdwViewStack` to provide this functionality.
+
+`AdwViewStack` pages can have a title, an icon, an attention request, and a
+numbered badge that [class@Adw.ViewSwitcher] will use to let users identify
+which page is which.
+Set them using the [property@Adw.ViewStackPage:title],
+[property@Adw.ViewStackPage:icon-name],
+[property@Adw.ViewStackPage:needs-attention], and
+[property@Adw.ViewStackPage:badge-number] properties.
+
+Transitions between views are animated by crossfading.
+These animations respect the [property@Gtk.Settings:gtk-enable-animations]
+setting.
+
+`AdwViewStack` maintains a [class@Adw.ViewStackPage] object for each added
+child, which holds additional per-child properties.
+You obtain the [class@Adw.ViewStackPage] for a child with
+[method@Adw.ViewStack.get_page] and you can obtain a
+[iface@Gtk.SelectionModel] containing all the pages with
+[method@Adw.ViewStack.get_pages].
+
+## AdwViewStack as GtkBuildable
+
+To set child-specific properties in a .ui file, create
+[class@Adw.ViewStackPage] objects explicitly, and set the child widget as a
+property on it:
+
+```xml
+  &lt;object class="AdwViewStack" id="stack"&gt;
+    &lt;child&gt;
+      &lt;object class="AdwViewStackPage"&gt;
+        &lt;property name="name"&gt;overview&lt;/property&gt;
+        &lt;property name="title"&gt;Overview&lt;/property&gt;
+        &lt;property name="child"&gt;
+          &lt;object class="AdwStatusPage"&gt;
+            &lt;property name="title"&gt;Welcome!&lt;/property&gt;
+          &lt;/object&gt;
+        &lt;/property&gt;
+      &lt;/object&gt;
+    &lt;/child&gt;
+```
+
+## CSS nodes
+
+`AdwViewStack` has a single CSS node named `stack`.</doc>
+      <source-position filename="../src/adw-view-stack.h" line="77"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new" c:identifier="adw_view_stack_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1640">Creates a new `AdwViewStack`.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="80"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1645">the newly created `AdwViewStack`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="add" c:identifier="adw_view_stack_add" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1655">Adds a child to @self.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="83"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1662">the [class@Adw.ViewStackPage] for @child</doc>
+          <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1657">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1658">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_named"
+              c:identifier="adw_view_stack_add_named"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1676">Adds a child to @self.
+
+The child is identified by the @name.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="86"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1686">the `AdwViewStackPage` for @child</doc>
+          <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1678">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1679">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1680">the name for @child</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="add_titled"
+              c:identifier="adw_view_stack_add_titled"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1701">Adds a child to @self.
+
+The child is identified by the @name. The @title will be used by
+[class@Adw.ViewSwitcher] to represent @child, so it should be short.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="90"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1713">the `AdwViewStackPage` for @child</doc>
+          <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1703">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1704">the widget to add</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1705">the name for @child</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1706">a human-readable title for @child</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_child_by_name"
+              c:identifier="adw_view_stack_get_child_by_name"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1783">Finds the child with @name in @self.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="104"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1790">the requested child</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1785">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1786">the name of the child to find</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_hhomogeneous"
+              c:identifier="adw_view_stack_get_hhomogeneous"
+              glib:get-property="hhomogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="hhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1934">Gets whether @self is horizontally homogeneous.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="123"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1940">whether @self is horizontally homogeneous</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1936">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_interpolate_size"
+              c:identifier="adw_view_stack_get_interpolate_size"
+              glib:get-property="interpolate-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="interpolate-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="2041">Gets whether @self will interpolate its size when changing the visible child.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="138"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="2047">whether child sizes are interpolated</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="2043">A `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_page"
+              c:identifier="adw_view_stack_get_page"
+              version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1762">Gets the [class@Adw.ViewStackPage] object for @child.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="100"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1769">the page object for @child</doc>
+          <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1764">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1765">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="get_pages"
+              c:identifier="adw_view_stack_get_pages"
+              glib:get-property="pages"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="2059">Returns a [iface@Gio.ListModel] that contains the pages of the stack.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the visible
+page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="141"/>
+        <return-value transfer-ownership="full">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="2069">a `GtkSelectionModel` for the stack's children</doc>
+          <type name="Gtk.SelectionModel" c:type="GtkSelectionModel*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="2061">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_transition_running"
+              c:identifier="adw_view_stack_get_transition_running"
+              glib:get-property="transition-running"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="transition-running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1998">Gets whether the @self is currently in a transition from one page to another.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="132"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="2004">whether a transition is currently running</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="2000">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_vhomogeneous"
+              c:identifier="adw_view_stack_get_vhomogeneous"
+              glib:get-property="vhomogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="vhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1980">Gets whether @self is vertically homogeneous.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="129"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1986">whether @self is vertically homogeneous</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1982">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_child"
+              c:identifier="adw_view_stack_get_visible_child"
+              glib:get-property="visible-child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="visible-child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1808">Gets the currently visible child of @self, .</doc>
+        <source-position filename="../src/adw-view-stack.h" line="111"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1814">the visible child</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1810">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible_child_name"
+              c:identifier="adw_view_stack_get_visible_child_name"
+              glib:get-property="visible-child-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="visible-child-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1856">Returns the name of the currently visible child of @self.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="117"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1862">the name of the visible child</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1858">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="remove" c:identifier="adw_view_stack_remove" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1729">Removes a child widget from @self.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="96"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1731">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1732">the child to remove</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_hhomogeneous"
+              c:identifier="adw_view_stack_set_hhomogeneous"
+              glib:set-property="hhomogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="hhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1906">Sets @self to be horizontally homogeneous or not.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="120"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1908">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="hhomogeneous" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1909">whether to make @self horizontally homogeneous</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_interpolate_size"
+              c:identifier="adw_view_stack_set_interpolate_size"
+              glib:set-property="interpolate-size"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="interpolate-size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="2016">Sets whether @self will interpolate its size when changing the visible child.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="135"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="2018">A `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="interpolate_size" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="2019">the new value</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_vhomogeneous"
+              c:identifier="adw_view_stack_set_vhomogeneous"
+              glib:set-property="vhomogeneous"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="vhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1952">Sets @self to be vertically homogeneous or not.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="126"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1954">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="vhomogeneous" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1955">whether to make @self vertically homogeneous</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_child"
+              c:identifier="adw_view_stack_set_visible_child"
+              glib:set-property="visible-child"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="visible-child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1826">Makes @child the visible child of @self.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="108"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1828">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="child" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1829">a child of @self</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible_child_name"
+              c:identifier="adw_view_stack_set_visible_child_name"
+              glib:set-property="visible-child-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="visible-child-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1874">Makes the child with @name visible.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="114"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1876">a `AdwViewStack`</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </instance-parameter>
+          <parameter name="name" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1877">the name of the child</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="hhomogeneous"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_hhomogeneous"
+                getter="get_hhomogeneous">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_hhomogeneous"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_set_hhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1153">Whether the stack allocates the same width for all children.
+
+If it's `FALSE`, the stack may change width when a different child becomes
+visible.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="interpolate-size"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_interpolate_size"
+                getter="get_interpolate_size">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_interpolate_size"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_set_interpolate_size"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1231">Whether the stack interpolates its size when changing the visible child.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="pages" transfer-ownership="none" getter="get_pages">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_pages"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1245">A selection model with the stack's pages.
+
+This can be used to keep an up-to-date view. The model also implements
+[iface@Gtk.SelectionModel] and can be used to track and change the visible
+page.</doc>
+        <type name="Gtk.SelectionModel"/>
+      </property>
+      <property name="transition-running"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_transition_running">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_transition_running"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1217">Whether a transition is currently running.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="vhomogeneous"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_vhomogeneous"
+                getter="get_vhomogeneous">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_vhomogeneous"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_set_vhomogeneous"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1170">Whether the stack allocates the same height for all children.
+
+If it's `FALSE`, the stack may change height when a different child becomes
+visible.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="visible-child"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_child"
+                getter="get_visible_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_visible_child"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_set_visible_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1187">The widget currently visible in the stack.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="visible-child-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible_child_name"
+                getter="get_visible_child_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_get_visible_child_name"/>
+        <attribute name="org.gtk.Poperty.set"
+                   value="adw_view_stack_set_visible_child_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1201">The name of the widget currently visible in the stack.
+
+See [property@Adw.ViewStack:visible-child].</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="ViewStackClass"
+            c:type="AdwViewStackClass"
+            glib:is-gtype-struct-for="ViewStack">
+      <source-position filename="../src/adw-view-stack.h" line="77"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="ViewStackPage"
+           c:symbol-prefix="view_stack_page"
+           c:type="AdwViewStackPage"
+           version="1.0"
+           parent="GObject.Object"
+           glib:type-name="AdwViewStackPage"
+           glib:get-type="adw_view_stack_page_get_type"
+           glib:type-struct="ViewStackPageClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-stack.c"
+           line="83">An auxiliary class used by [class@Adw.ViewStack].</doc>
+      <source-position filename="../src/adw-view-stack.h" line="28"/>
+      <method name="get_badge_number"
+              c:identifier="adw_view_stack_page_get_badge_number"
+              glib:get-property="badge-number"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="badge-number"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1408">Gets the badge number for this page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="46"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1414">the badge number for this page</doc>
+          <type name="guint" c:type="guint"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1410">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_child"
+              c:identifier="adw_view_stack_page_get_child"
+              glib:get-property="child"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1298">Gets the stack child to which @self belongs.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="31"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1304">the child to which @self belongs</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1300">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_icon_name"
+              c:identifier="adw_view_stack_page_get_icon_name"
+              glib:get-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1598">Gets the icon name of the page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="69"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1604">the icon name of the page</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1600">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_name"
+              c:identifier="adw_view_stack_page_get_name"
+              glib:get-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1488">Gets the name of the page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="58"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1494">the name of the page</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1490">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_needs_attention"
+              c:identifier="adw_view_stack_page_get_needs_attention"
+              glib:get-property="needs-attention"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="needs-attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1365">Gets whether the page is marked as “needs attention”.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="40"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1371">whether the page needs attention</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1367">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_view_stack_page_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1556">Gets the page title.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="64"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1562">the page title</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1558">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_use_underline"
+              c:identifier="adw_view_stack_page_get_use_underline"
+              glib:get-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1449">Gets whether underlines in the page title indicate mnemonics.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="52"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1455">whether underlines in the page title indicate mnemonics</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1451">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_visible"
+              c:identifier="adw_view_stack_page_get_visible"
+              glib:get-property="visible"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="visible"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1316">Gets whether @self is visible in its `AdwViewStack`.
+
+This is independent from the [property@Gtk.Widget:visible]
+property of its widget.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="34"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-stack.c"
+               line="1325">whether @self is visible</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1318">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_badge_number"
+              c:identifier="adw_view_stack_page_set_badge_number"
+              glib:set-property="badge-number"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="badge-number"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1426">Sets the badge number for this page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="48"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1428">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="badge_number" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1429">the new value to set</doc>
+            <type name="guint" c:type="guint"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_icon_name"
+              c:identifier="adw_view_stack_page_set_icon_name"
+              glib:set-property="icon-name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="icon-name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1616">Sets the icon name of the page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="71"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1618">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="icon_name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1619">the icon name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_name"
+              c:identifier="adw_view_stack_page_set_name"
+              glib:set-property="name"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1506">Sets the name of the page.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="60"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1508">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="name"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1509">the page name</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_needs_attention"
+              c:identifier="adw_view_stack_page_set_needs_attention"
+              glib:set-property="needs-attention"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="needs-attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1383">Sets whether the page is marked as “needs attention”.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="42"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1385">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="needs_attention" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1386">the new value to set</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_view_stack_page_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1574">Sets the page title.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="66"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1576">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="title"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1577">the page title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_use_underline"
+              c:identifier="adw_view_stack_page_set_use_underline"
+              glib:set-property="use-underline"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="use-underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1465">Sets whether underlines in the page title indicate mnemonics.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="54"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1467">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="use_underline" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1468">the new value to set</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_visible"
+              c:identifier="adw_view_stack_page_set_visible"
+              glib:set-property="visible"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="visible"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="1337">Sets whether @page is visible in its `AdwViewStack`.</doc>
+        <source-position filename="../src/adw-view-stack.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1339">a `AdwViewStackPage`</doc>
+            <type name="ViewStackPage" c:type="AdwViewStackPage*"/>
+          </instance-parameter>
+          <parameter name="visible" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-stack.c"
+                 line="1340">whether @self is visible</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="badge-number"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_badge_number"
+                getter="get_badge_number">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_badge_number"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_badge_number"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="345">A number associated with the page.
+
+[class@Adw.ViewSwitcher] can display it as a badge next to the page icon.
+It is commonly used to display a number of unread items within the page.
+
+It can be used together with [property@Adw.ViewStack{age}:needs-attention].</doc>
+        <type name="guint" c:type="guint"/>
+      </property>
+      <property name="child"
+                version="1.0"
+                writable="1"
+                construct-only="1"
+                transfer-ownership="none"
+                getter="get_child">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_child"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="273">The child of the page.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <property name="icon-name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_icon_name"
+                getter="get_icon_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_icon_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_icon_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="315">The icon name of the child page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="name"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_name"
+                getter="get_name">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_name"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_name"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="287">The name of the child page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="needs-attention"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_needs_attention"
+                getter="get_needs_attention">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_needs_attention"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_needs_attention"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="329">Whether the page requires the user attention.
+
+[class@Adw.ViewSwitcher] will display it as a dot next to the page icon.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="301">The title of the child page.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="use-underline"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_use_underline"
+                getter="get_use_underline">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_use_underline"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_use_underline"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="381">Whether an embedded underline in the title indicates a mnemonic.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="visible"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_visible"
+                getter="get_visible">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_stack_page_get_visible"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_stack_page_set_visible"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-stack.c"
+             line="364">Whether this page is visible.
+
+This is independent from the [property@Gtk.Widget:visible] property of
+[property@Adw.ViewStackPage:child].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="ViewStackPageClass"
+            c:type="AdwViewStackPageClass"
+            glib:is-gtype-struct-for="ViewStackPage">
+      <source-position filename="../src/adw-view-stack.h" line="28"/>
+      <field name="parent_class">
+        <type name="GObject.ObjectClass" c:type="GObjectClass"/>
+      </field>
+    </record>
+    <class name="ViewSwitcher"
+           c:symbol-prefix="view_switcher"
+           c:type="AdwViewSwitcher"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwViewSwitcher"
+           glib:get-type="adw_view_switcher_get_type"
+           glib:type-struct="ViewSwitcherClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-switcher.c"
+           line="17">An adaptive view switcher.
+
+An adaptive view switcher designed to switch between multiple views
+contained in a [class@Adw.ViewStack] in a similar fashion to
+[class@Gtk.StackSwitcher].
+
+Depending on the available width, the view switcher can adapt from a wide
+mode showing the view's icon and title side by side, to a narrow mode showing
+the view's icon and title one on top of the other, in a more compact way.
+This can be controlled via the [property@Adw.ViewSwitcher:policy] property.
+
+## CSS nodes
+
+`AdwViewSwitcher` has a single CSS node with name `viewswitcher`.
+
+## Accessibility
+
+`AdwViewSwitcher` uses the `GTK_ACCESSIBLE_ROLE_TAB_LIST` role and uses the
+`GTK_ACCESSIBLE_ROLE_TAB` for its buttons.</doc>
+      <source-position filename="../src/adw-view-switcher.h" line="25"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_view_switcher_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="386">Creates a new `AdwViewSwitcher`.</doc>
+        <source-position filename="../src/adw-view-switcher.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher.c"
+               line="391">the newly created `AdwViewSwitcher`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_policy"
+              c:identifier="adw_view_switcher_get_policy"
+              glib:get-property="policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="401">Gets the policy of @self.</doc>
+        <source-position filename="../src/adw-view-switcher.h" line="36"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher.c"
+               line="407">the policy of @self</doc>
+          <type name="ViewSwitcherPolicy" c:type="AdwViewSwitcherPolicy"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="403">a `AdwViewSwitcher`</doc>
+            <type name="ViewSwitcher" c:type="AdwViewSwitcher*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_stack"
+              c:identifier="adw_view_switcher_get_stack"
+              glib:get-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="452">Gets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher.h" line="42"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher.c"
+               line="458">the stack</doc>
+          <type name="ViewStack" c:type="AdwViewStack*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="454">a `AdwViewSwitcher`</doc>
+            <type name="ViewSwitcher" c:type="AdwViewSwitcher*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_policy"
+              c:identifier="adw_view_switcher_set_policy"
+              glib:set-property="policy"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="419">Sets the policy of @self.</doc>
+        <source-position filename="../src/adw-view-switcher.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="421">a `AdwViewSwitcher`</doc>
+            <type name="ViewSwitcher" c:type="AdwViewSwitcher*"/>
+          </instance-parameter>
+          <parameter name="policy" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="422">the new policy</doc>
+            <type name="ViewSwitcherPolicy" c:type="AdwViewSwitcherPolicy"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_stack"
+              c:identifier="adw_view_switcher_set_stack"
+              glib:set-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="470">Sets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher.h" line="44"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="472">a `AdwViewSwitcher`</doc>
+            <type name="ViewSwitcher" c:type="AdwViewSwitcher*"/>
+          </instance-parameter>
+          <parameter name="stack"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher.c"
+                 line="473">a stack</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="policy"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_policy"
+                getter="get_policy">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_get_policy"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_set_policy"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="340">The policy to determine which mode to use.</doc>
+        <type name="ViewSwitcherPolicy"/>
+      </property>
+      <property name="stack"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_stack"
+                getter="get_stack">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_get_stack"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_set_stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="355">The stack the view switcher controls.</doc>
+        <type name="ViewStack"/>
+      </property>
+    </class>
+    <class name="ViewSwitcherBar"
+           c:symbol-prefix="view_switcher_bar"
+           c:type="AdwViewSwitcherBar"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwViewSwitcherBar"
+           glib:get-type="adw_view_switcher_bar_get_type"
+           glib:type-struct="ViewSwitcherBarClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-switcher-bar.c"
+           line="13">A view switcher action bar.
+
+An action bar letting you switch between multiple views contained in a
+[class@Adw.ViewStack], via an [class@Adw.ViewSwitcher]. It is designed to be put
+at the bottom of a window and to be revealed only on really narrow windows,
+e.g. on mobile phones. It can't be revealed if there are less than two pages.
+
+You can conveniently bind the [property@Adw.ViewSwitcherBar:reveal] property
+to [property@Adw.ViewSwitcherTitle:title-visible] to automatically reveal the
+view switcher bar when the title label is displayed in place of the view
+switcher.
+
+An example of the UI definition for a common use case:
+
+```xml
+&lt;object class="GtkWindow"/&gt;
+  &lt;child type="titlebar"&gt;
+    &lt;object class="AdwHeaderBar"&gt;
+      &lt;property name="centering-policy"&gt;strict&lt;/property&gt;
+      &lt;child type="title"&gt;
+        &lt;object class="AdwViewSwitcherTitle" id="title"&gt;
+          &lt;property name="stack"&gt;stack&lt;/property&gt;
+        &lt;/object&gt;
+      &lt;/child&gt;
+    &lt;/object&gt;
+  &lt;/child&gt;
+  &lt;child&gt;
+    &lt;object class="GtkBox"&gt;
+      &lt;child&gt;
+        &lt;object class="AdwViewStack" id="stack"/&gt;
+      &lt;/child&gt;
+      &lt;child&gt;
+        &lt;object class="AdwViewSwitcherBar"&gt;
+          &lt;property name="stack"&gt;stack&lt;/property&gt;
+          &lt;binding name="reveal"&gt;
+            &lt;lookup name="title-visible"&gt;title&lt;/lookup&gt;
+          &lt;/binding&gt;
+        &lt;/object&gt;
+      &lt;/child&gt;
+    &lt;/object&gt;
+  &lt;/child&gt;
+&lt;/object&gt;
+```
+
+## CSS nodes
+
+`AdwViewSwitcherBar` has a single CSS node with name` viewswitcherbar`.</doc>
+      <source-position filename="../src/adw-view-switcher-bar.h" line="25"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_view_switcher_bar_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="224">Creates a new `AdwViewSwitcherBar`.</doc>
+        <source-position filename="../src/adw-view-switcher-bar.h" line="28"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-bar.c"
+               line="229">the newly created `AdwViewSwitcherBar`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_reveal"
+              c:identifier="adw_view_switcher_bar_get_reveal"
+              glib:get-property="reveal"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="reveal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="298">Gets whether @self should be revealed or hidden.</doc>
+        <source-position filename="../src/adw-view-switcher-bar.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-bar.c"
+               line="304">whether @self is revealed</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="300">a `AdwViewSwitcherBar`</doc>
+            <type name="ViewSwitcherBar" c:type="AdwViewSwitcherBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_stack"
+              c:identifier="adw_view_switcher_bar_get_stack"
+              glib:get-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="239">Gets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher-bar.h" line="31"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-bar.c"
+               line="245">the stack</doc>
+          <type name="ViewStack" c:type="AdwViewStack*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="241">a `AdwViewSwitcherBar`</doc>
+            <type name="ViewSwitcherBar" c:type="AdwViewSwitcherBar*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_reveal"
+              c:identifier="adw_view_switcher_bar_set_reveal"
+              glib:set-property="reveal"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="reveal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="316">Sets whether @self should be revealed or hidden.</doc>
+        <source-position filename="../src/adw-view-switcher-bar.h" line="39"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="318">a `AdwViewSwitcherBar`</doc>
+            <type name="ViewSwitcherBar" c:type="AdwViewSwitcherBar*"/>
+          </instance-parameter>
+          <parameter name="reveal" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="319">whether to reveal @self</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_stack"
+              c:identifier="adw_view_switcher_bar_set_stack"
+              glib:set-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="257">Sets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher-bar.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="259">a `AdwViewSwitcherBar`</doc>
+            <type name="ViewSwitcherBar" c:type="AdwViewSwitcherBar*"/>
+          </instance-parameter>
+          <parameter name="stack"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-bar.c"
+                 line="260">a stack</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="reveal"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_reveal"
+                getter="get_reveal">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_bar_get_reveal"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_bar_set_reveal"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="189">Whether the bar should be revealed or hidden.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="stack"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_stack"
+                getter="get_stack">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_bar_get_stack"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_bar_set_stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-bar.c"
+             line="175">The stack the view switcher controls.</doc>
+        <type name="ViewStack"/>
+      </property>
+    </class>
+    <record name="ViewSwitcherBarClass"
+            c:type="AdwViewSwitcherBarClass"
+            glib:is-gtype-struct-for="ViewSwitcherBar">
+      <source-position filename="../src/adw-view-switcher-bar.h" line="25"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <record name="ViewSwitcherClass"
+            c:type="AdwViewSwitcherClass"
+            glib:is-gtype-struct-for="ViewSwitcher">
+      <source-position filename="../src/adw-view-switcher.h" line="25"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <enumeration name="ViewSwitcherPolicy"
+                 glib:type-name="AdwViewSwitcherPolicy"
+                 glib:get-type="adw_view_switcher_policy_get_type"
+                 c:type="AdwViewSwitcherPolicy">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-switcher.c"
+           line="43">Describes the adaptive modes of [class@Adw.ViewSwitcher].</doc>
+      <member name="narrow"
+              value="0"
+              c:identifier="ADW_VIEW_SWITCHER_POLICY_NARROW"
+              glib:nick="narrow"
+              glib:name="ADW_VIEW_SWITCHER_POLICY_NARROW">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="45">Force the narrow mode</doc>
+      </member>
+      <member name="wide"
+              value="1"
+              c:identifier="ADW_VIEW_SWITCHER_POLICY_WIDE"
+              glib:nick="wide"
+              glib:name="ADW_VIEW_SWITCHER_POLICY_WIDE">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher.c"
+             line="46">Force the wide mode</doc>
+      </member>
+    </enumeration>
+    <class name="ViewSwitcherTitle"
+           c:symbol-prefix="view_switcher_title"
+           c:type="AdwViewSwitcherTitle"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwViewSwitcherTitle"
+           glib:get-type="adw_view_switcher_title_get_type"
+           glib:type-struct="ViewSwitcherTitleClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-view-switcher-title.c"
+           line="14">A view switcher title.
+
+A widget letting you switch between multiple views contained by a
+[class@Adw.ViewStack] via an [class@Adw.ViewSwitcher].
+
+It is designed to be used as the title widget of a [class@Adw.HeaderBar], and
+will display the window's title when the window is too narrow to fit the view
+switcher e.g. on mobile phones, or if there are less than two views.
+
+You can conveniently bind the [property@Adw.ViewSwitcherBar:reveal] property
+to [property@Adw.ViewSwitcherTitle:title-visible] to automatically reveal the
+view switcher bar when the title label is displayed in place of the view
+switcher.
+
+An example of the UI definition for a common use case:
+
+```xml
+&lt;object class="GtkWindow"/&gt;
+  &lt;child type="titlebar"&gt;
+    &lt;object class="AdwHeaderBar"&gt;
+      &lt;property name="centering-policy"&gt;strict&lt;/property&gt;
+      &lt;child type="title"&gt;
+        &lt;object class="AdwViewSwitcherTitle" id="title"&gt;
+          &lt;property name="stack"&gt;stack&lt;/property&gt;
+        &lt;/object&gt;
+      &lt;/child&gt;
+    &lt;/object&gt;
+  &lt;/child&gt;
+  &lt;child&gt;
+    &lt;object class="GtkBox"&gt;
+      &lt;child&gt;
+        &lt;object class="AdwViewStack" id="stack"/&gt;
+      &lt;/child&gt;
+      &lt;child&gt;
+        &lt;object class="AdwViewSwitcherBar"&gt;
+          &lt;property name="stack"&gt;stack&lt;/property&gt;
+          &lt;binding name="reveal"&gt;
+            &lt;lookup name="title-visible"&gt;title&lt;/lookup&gt;
+          &lt;/binding&gt;
+        &lt;/object&gt;
+      &lt;/child&gt;
+    &lt;/object&gt;
+  &lt;/child&gt;
+&lt;/object&gt;
+```
+
+## CSS nodes
+
+`AdwViewSwitcherTitle` has a single CSS node with name `viewswitchertitle`.</doc>
+      <source-position filename="../src/adw-view-switcher-title.h" line="25"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_view_switcher_title_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="323">Creates a new `AdwViewSwitcherTitle`.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="28"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="328">the newly created `AdwViewSwitcherTitle`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_stack"
+              c:identifier="adw_view_switcher_title_get_stack"
+              glib:get-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="338">Gets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="31"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="344">the stack</doc>
+          <type name="ViewStack" c:type="AdwViewStack*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="340">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_subtitle"
+              c:identifier="adw_view_switcher_title_get_subtitle"
+              glib:get-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="439">Gets the subtitle of @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="43"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="445">the subtitle</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="441">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_view_switcher_title_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="398">Gets the title of @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="37"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="404">the title</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="400">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title_visible"
+              c:identifier="adw_view_switcher_title_get_title_visible"
+              glib:get-property="title-visible"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title-visible"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="524">Gets whether the title of @self is currently visible.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="55"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="530">whether the title of @self is currently visible</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="526">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_view_switcher_enabled"
+              c:identifier="adw_view_switcher_title_get_view_switcher_enabled"
+              glib:get-property="view-switcher-enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property"
+                   value="view-switcher-enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="480">Gets whether @self's view switcher is enabled.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="49"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-view-switcher-title.c"
+               line="486">whether the view switcher is enabled</doc>
+          <type name="gboolean" c:type="gboolean"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="482">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_stack"
+              c:identifier="adw_view_switcher_title_set_stack"
+              glib:set-property="stack"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="356">Sets the stack controlled by @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="33"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="358">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+          <parameter name="stack"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="359">a stack</doc>
+            <type name="ViewStack" c:type="AdwViewStack*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_subtitle"
+              c:identifier="adw_view_switcher_title_set_subtitle"
+              glib:set-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="457">Sets the subtitle of @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="45"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="459">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+          <parameter name="subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="460">a subtitle</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_view_switcher_title_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="416">Sets the title of @self.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="39"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="418">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="419">a title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_view_switcher_enabled"
+              c:identifier="adw_view_switcher_title_set_view_switcher_enabled"
+              glib:set-property="view-switcher-enabled"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property"
+                   value="view-switcher-enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="498">Sets whether @self's view switcher is enabled.</doc>
+        <source-position filename="../src/adw-view-switcher-title.h"
+                         line="51"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="500">a `AdwViewSwitcherTitle`</doc>
+            <type name="ViewSwitcherTitle" c:type="AdwViewSwitcherTitle*"/>
+          </instance-parameter>
+          <parameter name="enabled" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-view-switcher-title.c"
+                 line="501">whether the view switcher is enabled</doc>
+            <type name="gboolean" c:type="gboolean"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="stack"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_stack"
+                getter="get_stack">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_title_get_stack"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_title_set_stack"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="211">The stack the view switcher controls.</doc>
+        <type name="ViewStack"/>
+      </property>
+      <property name="subtitle"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_subtitle"
+                getter="get_subtitle">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_title_get_subtitle"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_title_set_subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="242">The subtitle to display.
+
+The subtitle should give a user additional details.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_title_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_title_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="225">The title to display.
+
+The title should give a user additional details. A good title should not
+include the application name.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="title-visible"
+                version="1.0"
+                transfer-ownership="none"
+                getter="get_title_visible">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_title_get_title_visible"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="279">Whether the title is currently visible.
+
+If the title is visible, it means the view switcher is hidden an it may be
+wanted to show an alternative switcher, e.g. a [class@Adw.ViewSwitcherBar].</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="view-switcher-enabled"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_view_switcher_enabled"
+                getter="get_view_switcher_enabled">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_view_switcher_title_get_view_switcher_enabled"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_view_switcher_title_set_view_switcher_enabled"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-view-switcher-title.c"
+             line="258">Whether the view switcher is enabled.
+
+If it is disabled, the title will be displayed instead. This allows to
+programmatically hide the view switcher even if it fits in the available
+space.
+
+This can be used e.g. to ensure the view switcher is hidden below a certain
+window width, or any other constraint you find suitable.</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <record name="ViewSwitcherTitleClass"
+            c:type="AdwViewSwitcherTitleClass"
+            glib:is-gtype-struct-for="ViewSwitcherTitle">
+      <source-position filename="../src/adw-view-switcher-title.h" line="25"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <class name="Window"
+           c:symbol-prefix="window"
+           c:type="AdwWindow"
+           version="1.0"
+           parent="Gtk.Window"
+           glib:type-name="AdwWindow"
+           glib:get-type="adw_window_get_type"
+           glib:type-struct="WindowClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-window.c"
+           line="12">A freeform window.
+
+The `AdwWindow` widget is a subclass of [class@Gtk.Window] which has no
+titlebar area. It means [class@Gtk.HeaderBar] can be used as follows:
+
+```xml
+&lt;object class="AdwWindow"&gt;
+  &lt;property name="content"&gt;
+    &lt;object class="GtkBox"&gt;
+      &lt;property name="orientation"&gt;vertical&lt;/property&gt;
+      &lt;child&gt;
+        &lt;object class="GtkHeaderBar"/&gt;
+      &lt;/child&gt;
+      &lt;child&gt;
+        ...
+      &lt;/child&gt;
+    &lt;/object&gt;
+  &lt;/property&gt;
+&lt;/object&gt;
+```
+
+Using [method@Gtk.Window.get_titlebar] and [method@Gtk.Window.set_titlebar]
+is not supported and will result in a crash.</doc>
+      <source-position filename="../src/adw-window.h" line="30"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <implements name="Gtk.Native"/>
+      <implements name="Gtk.Root"/>
+      <implements name="Gtk.ShortcutManager"/>
+      <constructor name="new" c:identifier="adw_window_new" version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-window.c"
+             line="181">Creates a new `AdwWindow`.</doc>
+        <source-position filename="../src/adw-window.h" line="33"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-window.c"
+               line="186">the newly created `AdwWindow`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+      </constructor>
+      <method name="get_content"
+              c:identifier="adw_window_get_content"
+              glib:get-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window.c"
+             line="219">Gets the content widget of @self.
+
+This method should always be used instead of [method@Gtk.Window.get_child].</doc>
+        <source-position filename="../src/adw-window.h" line="36"/>
+        <return-value transfer-ownership="none" nullable="1">
+          <doc xml:space="preserve"
+               filename="../src/adw-window.c"
+               line="227">the content widget of @self</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window.c"
+                 line="221">a `AdwWindow`</doc>
+            <type name="Window" c:type="AdwWindow*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_content"
+              c:identifier="adw_window_set_content"
+              glib:set-property="content"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window.c"
+             line="196">Sets the content widget of @self.
+
+This method should always be used instead of [method@Gtk.Window.set_child].</doc>
+        <source-position filename="../src/adw-window.h" line="38"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window.c"
+                 line="198">a `AdwWindow`</doc>
+            <type name="Window" c:type="AdwWindow*"/>
+          </instance-parameter>
+          <parameter name="content"
+                     transfer-ownership="none"
+                     nullable="1"
+                     allow-none="1">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window.c"
+                 line="199">the content widget</doc>
+            <type name="Gtk.Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="content"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_content"
+                getter="get_content">
+        <attribute name="org.gtk.Property.get" value="adw_window_get_content"/>
+        <attribute name="org.gtk.Property.set" value="adw_window_set_content"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window.c"
+             line="133">The content widget.</doc>
+        <type name="Gtk.Widget"/>
+      </property>
+      <field name="parent_instance">
+        <type name="Gtk.Window" c:type="GtkWindow"/>
+      </field>
+    </class>
+    <record name="WindowClass"
+            c:type="AdwWindowClass"
+            glib:is-gtype-struct-for="Window">
+      <source-position filename="../src/adw-window.h" line="30"/>
+      <field name="parent_class">
+        <type name="Gtk.WindowClass" c:type="GtkWindowClass"/>
+      </field>
+      <field name="padding" readable="0" private="1">
+        <array zero-terminated="0" fixed-size="4">
+          <type name="gpointer" c:type="gpointer"/>
+        </array>
+      </field>
+    </record>
+    <class name="WindowTitle"
+           c:symbol-prefix="window_title"
+           c:type="AdwWindowTitle"
+           version="1.0"
+           parent="Gtk.Widget"
+           glib:type-name="AdwWindowTitle"
+           glib:get-type="adw_window_title_get_type"
+           glib:type-struct="WindowTitleClass">
+      <doc xml:space="preserve"
+           filename="../src/adw-window-title.c"
+           line="11">A helper widget for setting a window's title and subtitle.
+
+`AdwWindowTitle` shows a title and subtitle. It's intended to be used as the
+title child of [class@Gtk.HeaderBar] or [class@Adw.HeaderBar].
+
+## CSS nodes
+
+`AdwWindowTitle` has a single CSS node with name `windowtitle`.</doc>
+      <source-position filename="../src/adw-window-title.h" line="22"/>
+      <implements name="Gtk.Accessible"/>
+      <implements name="Gtk.Buildable"/>
+      <implements name="Gtk.ConstraintTarget"/>
+      <constructor name="new"
+                   c:identifier="adw_window_title_new"
+                   version="1.0">
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="160">Creates a new `AdwWindowTitle`.</doc>
+        <source-position filename="../src/adw-window-title.h" line="25"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-window-title.c"
+               line="167">the newly created `AdwWindowTitle`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </return-value>
+        <parameters>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="162">a title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+          <parameter name="subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="163">a subtitle</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </constructor>
+      <method name="get_subtitle"
+              c:identifier="adw_window_title_get_subtitle"
+              glib:get-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="224">Gets the subtitle of @self.</doc>
+        <source-position filename="../src/adw-window-title.h" line="35"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-window-title.c"
+               line="230">the subtitle</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="226">a `AdwWindowTitle`</doc>
+            <type name="WindowTitle" c:type="AdwWindowTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="get_title"
+              c:identifier="adw_window_title_get_title"
+              glib:get-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.get_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="181">Gets the title of @self.</doc>
+        <source-position filename="../src/adw-window-title.h" line="29"/>
+        <return-value transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-window-title.c"
+               line="187">the title</doc>
+          <type name="utf8" c:type="const char*"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="183">a `AdwWindowTitle`</doc>
+            <type name="WindowTitle" c:type="AdwWindowTitle*"/>
+          </instance-parameter>
+        </parameters>
+      </method>
+      <method name="set_subtitle"
+              c:identifier="adw_window_title_set_subtitle"
+              glib:set-property="subtitle"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="242">Sets the subtitle of @self.</doc>
+        <source-position filename="../src/adw-window-title.h" line="37"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="244">a `AdwWindowTitle`</doc>
+            <type name="WindowTitle" c:type="AdwWindowTitle*"/>
+          </instance-parameter>
+          <parameter name="subtitle" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="245">a subtitle</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <method name="set_title"
+              c:identifier="adw_window_title_set_title"
+              glib:set-property="title"
+              version="1.0">
+        <attribute name="org.gtk.Method.set_property" value="title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="199">Sets the title of @self.</doc>
+        <source-position filename="../src/adw-window-title.h" line="31"/>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="201">a `AdwWindowTitle`</doc>
+            <type name="WindowTitle" c:type="AdwWindowTitle*"/>
+          </instance-parameter>
+          <parameter name="title" transfer-ownership="none">
+            <doc xml:space="preserve"
+                 filename="../src/adw-window-title.c"
+                 line="202">a title</doc>
+            <type name="utf8" c:type="const char*"/>
+          </parameter>
+        </parameters>
+      </method>
+      <property name="subtitle"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_subtitle"
+                getter="get_subtitle">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_window_title_get_subtitle"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_window_title_set_subtitle"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="132">The subtitle to display.
+
+The subtitle should give a user additional details.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <property name="title"
+                version="1.0"
+                writable="1"
+                transfer-ownership="none"
+                setter="set_title"
+                getter="get_title">
+        <attribute name="org.gtk.Property.get"
+                   value="adw_window_title_get_title"/>
+        <attribute name="org.gtk.Property.set"
+                   value="adw_window_title_set_title"/>
+        <doc xml:space="preserve"
+             filename="../src/adw-window-title.c"
+             line="115">The title to display.
+
+The title typically identifies the current view or content item, and
+generally does not use the application name.</doc>
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+    <record name="WindowTitleClass"
+            c:type="AdwWindowTitleClass"
+            glib:is-gtype-struct-for="WindowTitle">
+      <source-position filename="../src/adw-window-title.h" line="22"/>
+      <field name="parent_class">
+        <type name="Gtk.WidgetClass" c:type="GtkWidgetClass"/>
+      </field>
+    </record>
+    <function name="ease_out_cubic"
+              c:identifier="adw_ease_out_cubic"
+              version="1.0">
+      <doc xml:space="preserve"
+           filename="../src/adw-animation-util.c"
+           line="34">Computes the ease out for @t.</doc>
+      <source-position filename="../src/adw-animation-util.h" line="21"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-animation-util.c"
+             line="40">the ease out for @t</doc>
+        <type name="gdouble" c:type="double"/>
+      </return-value>
+      <parameters>
+        <parameter name="t" transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-animation-util.c"
+               line="36">the term</doc>
+          <type name="gdouble" c:type="double"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="get_enable_animations"
+              c:identifier="adw_get_enable_animations"
+              version="1.0">
+      <doc xml:space="preserve"
+           filename="../src/adw-animation-util.c"
+           line="71">Checks whether animations are enabled for @widget.
+
+This should be used when implementing an animated widget to know whether to
+animate it or not.</doc>
+      <source-position filename="../src/adw-animation-util.h" line="24"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-animation-util.c"
+             line="80">whether animations are enabled for @widget</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+      <parameters>
+        <parameter name="widget" transfer-ownership="none">
+          <doc xml:space="preserve"
+               filename="../src/adw-animation-util.c"
+               line="73">a `GtkWidget`</doc>
+          <type name="Gtk.Widget" c:type="GtkWidget*"/>
+        </parameter>
+      </parameters>
+    </function>
+    <function name="get_major_version" c:identifier="adw_get_major_version">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.c"
+           line="13">Returns the major version number of the Adwaita library.
+
+For example, in libadwaita version 1.2.3 this is 1.
+
+This function is in the library, so it represents the libadwaita library
+your code is running against. Contrast with the %ADW_MAJOR_VERSION macro,
+which represents the major version of the libadwaita headers you have
+included when compiling your code.</doc>
+      <source-position filename="../src/adw-version.h" line="93"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-version.c"
+             line="25">the major version number of the Adwaita library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_micro_version" c:identifier="adw_get_micro_version">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.c"
+           line="53">Returns the micro version number of the Adwaita library.
+
+For example, in libadwaita version 1.2.3 this is 2.
+
+This function is in the library, so it represents the libadwaita library
+your code is running against. Contrast with the %ADW_MAJOR_VERSION macro,
+which represents the micro version of the libadwaita headers you have
+included when compiling your code.</doc>
+      <source-position filename="../src/adw-version.h" line="97"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-version.c"
+             line="65">the micro version number of the Adwaita library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="get_minor_version" c:identifier="adw_get_minor_version">
+      <doc xml:space="preserve"
+           filename="../src/adw-version.c"
+           line="33">Returns the minor version number of the Adwaita library.
+
+For example, in libadwaita version 1.2.3 this is 2.
+
+This function is in the library, so it represents the libadwaita library
+your code is running against. Contrast with the %ADW_MAJOR_VERSION macro,
+which represents the minor version of the libadwaita headers you have
+included when compiling your code.</doc>
+      <source-position filename="../src/adw-version.h" line="95"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-version.c"
+             line="45">the minor version number of the Adwaita library</doc>
+        <type name="guint" c:type="guint"/>
+      </return-value>
+    </function>
+    <function name="init" c:identifier="adw_init" version="1.0">
+      <doc xml:space="preserve"
+           filename="../src/adw-main.c"
+           line="16">Initializes Libadwaita.
+
+Call this function just after initializing GTK, if you are using
+[class@Gtk.Application] it means it must be called when the
+[signal@Gio.Application::startup] signal is emitted.
+
+There's no need to call this function if you're using [class@Adw.Application].
+
+If Libadwaita has already been initialized, the function will simply return.
+
+This makes sure translations, types, themes, and icons for the Adwaita
+library are set up properly.</doc>
+      <source-position filename="../src/adw-main.h" line="19"/>
+      <return-value transfer-ownership="none">
+        <type name="none" c:type="void"/>
+      </return-value>
+    </function>
+    <function name="is_initialized" c:identifier="adw_is_initialized">
+      <doc xml:space="preserve"
+           filename="../src/adw-main.c"
+           line="52">Use this function to check if libadwaita has been initialized with
+adw_init().</doc>
+      <source-position filename="../src/adw-main.h" line="22"/>
+      <return-value transfer-ownership="none">
+        <doc xml:space="preserve"
+             filename="../src/adw-main.c"
+             line="58">the initialization status</doc>
+        <type name="gboolean" c:type="gboolean"/>
+      </return-value>
+    </function>
+  </namespace>
+</repository>

--- a/glue/Makefile
+++ b/glue/Makefile
@@ -22,8 +22,8 @@ ifndef JAVA_HOME
     JAVA_HOME = $$(dirname $$(dirname $$(readlink -f $$(which javac))))
 endif
 
-GTK_LIBS    != pkg-config --libs gtk4
-GTK_CFLAGS  != pkg-config --cflags gtk4
+GTK_LIBS    != pkg-config --libs gtk4 $(shell bash -c 'pkg-config  --exists libadwaita-1 && echo "libadwaita-1" || echo ""')
+GTK_CFLAGS  != pkg-config --cflags gtk4 $(shell bash -c 'pkg-config  --exists libadwaita-1 && echo "libadwaita-1" || echo ""')
 INCLUDE_DIRS = -I../java-gtk/build/generated/sources/headers/java/main/ -I$(JAVA_HOME)/include/ -I$(JAVA_HOME)/include/linux/
 
 LIBDIR=build/lib/glue/linux-$(ARCH)


### PR DESCRIPTION
The method ActionRow::activate had to be out-commented, as it caused name-clashes with another method and caused javac to error out.

I can port the example application to use Libadwaita+GTK4, or I can do another PR.


CI fails, as libadwaita is not available in the container that is used by the CI