### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 [![Build on Debian](https://github.com/bailuk/java-gtk/actions/workflows/build-on-debian.yml/badge.svg)](https://github.com/bailuk/java-gtk/actions/workflows/build-on-debian.yml)
 [![Build on Fedora](https://github.com/bailuk/java-gtk/actions/workflows/build-on-fedora.yml/badge.svg)](https://github.com/bailuk/java-gtk/actions/workflows/build-on-fedora.yml)
 [![Build on Ubuntu](https://github.com/bailuk/java-gtk/actions/workflows/build-on-ubuntu.yml/badge.svg)](https://github.com/bailuk/java-gtk/actions/workflows/build-on-ubuntu.yml)


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=bailuk&project=java-gtk&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
